### PR TITLE
Proof-reading of JSON API

### DIFF
--- a/src/frontend/jsonapi/basics.md
+++ b/src/frontend/jsonapi/basics.md
@@ -69,11 +69,13 @@ All GET requests will return a JSON object with the structure defined by [jsonap
 }
 ```
 
-The **"meta"** section will always contain a "total" property on success. It's value is the number of items found in total for the current search filter. In the **"links"** section, all necessary links for navigating through the result set are listed including the link for the current request.
+The **"meta"** section will always contain a "total" property on success. It's value is the number of items found in total for the current search filter.
+
+In the **"links"** section, all necessary links for navigating through the result set are listed including the link for the current request.
 
 **"data"** contains the product items, and each item always contains the ID and the resource type. In the attributes section, you will find the same data as returned by the *toArray()* method for every item. An URL referencing the unique resource is included in "links". If related items are included, they will be referenced by their ID and type in the "relationships" section. Items that are associated via lists will also contain an "attributes" section with the data for the list table.
 
-In the **"included"** section all related items are listed if you told the server to hand them over in the same request as well. Its structure is the same as for the "data" section. For more information, please have a look into at the [related resources](#include-related-resources) section.
+In the **"included"** section all related items are listed if you told the server to hand them over in the same request as well. Its structure is the same as for the "data" section. For more information, please have a look into the [related resources](#include-related-resources) section.
 
 By default, the first 48 items available will be returned if no further GET parameters are sent along with the request. There are three parameters to modify that behavior:
 
@@ -88,7 +90,7 @@ By default, the first 48 items available will be returned if no further GET para
 
 Each resource offers custom search parameters to retrieve data for common use cases. Please have a look into the articles about products, basket, etc. for details about these parameters.
 
-Additionally, you can use custom filters for each resource. The JSON API standard defines a parameter named "filter" that can contain arbitrary conditions. In the Aimeos API, you can use conditions for comparing values and combining them. To get all products items which are selections:
+Additionally, you can use custom filters for each resource. The JSON API standard defines a parameter named "filter" that can contain arbitrary conditions. In the Aimeos API you can use conditions for comparing values and combining them. E.g. to get all product items which are selections, you can do this:
 
 === "CURL"
     ```bash
@@ -97,14 +99,17 @@ Additionally, you can use custom filters for each resource. The JSON API standar
     ```
 === "jQuery"
     ```javascript
-    var params = {
+    var paramsObj = {
         'filter': {
             '>': {'product.type': 'select'}
         }
     };
+    var params;
 
     if(options.meta.prefix) { // returned from OPTIONS call
-        params[options.meta.prefix] = params;
+        params[options.meta.prefix] = paramsObj;
+    } else {
+        params = paramsObj;
     }
 
     $.ajax({
@@ -117,7 +122,7 @@ Additionally, you can use custom filters for each resource. The JSON API standar
     });
     ```
 
-This is known as the "polish" notation because the operator comes first, then the two operands (key and value). There are several operators available:
+This is known as the ["Polish"](https://en.wikipedia.org/wiki/Polish_notation) notation because the operator comes first, then the two operands (key and value). There are several operators available:
 
 **=~** (%3D%7E)
 : Strings that start with the given value
@@ -156,7 +161,7 @@ To combine several conditions into one request, you can combine two or more "com
     ```
 === "jQuery"
     ```javascript
-    var params = {
+    var paramsObj = {
         'filter': {
             '&&': [
                 {'>': {'product.type': 'select'}},
@@ -164,9 +169,12 @@ To combine several conditions into one request, you can combine two or more "com
             ]
         }
     };
+    var params;
 
     if(options.meta.prefix) { // returned from OPTIONS call
-        params[options.meta.prefix] = params;
+        params[options.meta.prefix] = paramsObj;
+    } else {
+        params = paramsObj;
     }
 
     $.ajax({
@@ -190,7 +198,7 @@ That would search for all product items which are selections AND whose labels st
 **!** (%21)
 : Negates an expression
 
-The negation is a special case because it only accepts one "compare" condition while the others require more than one condition. Nevertheless, the value of the negation operator must be an array like for the other "combine" operators:
+The negation is a special case because it only accepts one "compare" condition while the others require more than one condition. Nevertheless the value of the negation operator must be an array like the other "combine" operators:
 
 === "CURL"
     ```bash
@@ -199,16 +207,19 @@ The negation is a special case because it only accepts one "compare" condition w
     ```
 === "jQuery"
     ```javascript
-    var params = {
+    var paramsObj = {
         'filter': {
             '!': [
                 {'=~': {'product.code': 'demo-s'}}
             ]
         }
     };
+    var params;
 
     if(options.meta.prefix) { // returned from OPTIONS call
-        params[options.meta.prefix] = params;
+        params[options.meta.prefix] = paramsObj;
+    } else {
+        params = paramsObj;
     }
 
     $.ajax({
@@ -232,7 +243,7 @@ You can also create more complicated statements by nesting them like:
     ```
 === "jQuery"
     ```javascript
-    var params = {
+    var paramsObj = {
         'filter': {
             '&&': [
                 {'!': [
@@ -245,9 +256,12 @@ You can also create more complicated statements by nesting them like:
             ]
         }
     };
+    var params;
 
     if(options.meta.prefix) { // returned from OPTIONS call
-        params[options.meta.prefix] = params;
+        params[options.meta.prefix] = paramsObj;
+    } else {
+        params = paramsObj;
     }
 
     $.ajax({
@@ -260,7 +274,7 @@ You can also create more complicated statements by nesting them like:
     });
     ```
 
-It combines the three expression by using the AND operator. In the first expression we tell the server that we want to get all items whose code doesn't start with "demo-s". The second expression in this case is an OR expression that specifies that "product.datestart" can either be a null value or the start date must be a date after the beginning of the year 2000.
+It combines all three expressions by using the AND operator. In the first expression we tell the server that we want to get all items whose code doesn't start with "demo-s". The second expression in this case is an OR expression that specifies that "product.datestart" can either be a null value or the start date must be a date after the beginning of the year 2000.
 
 !!! warning
     Don't forget to [nest the parameters](index.md#nested-parameters) if a prefix is sent in the meta data!
@@ -277,12 +291,15 @@ Additionally, you can use the sort parameter and the items keys for generic sort
     ```
 === "jQuery"
     ```javascript
-    var params = {
+    var paramsObj = {
         'sort': 'product.label'
     };
+    var params;
 
     if(options.meta.prefix) { // returned from OPTIONS call
-        params[options.meta.prefix] = params;
+        params[options.meta.prefix] = paramsObj;
+    } else {
+        params = paramsObj;
     }
 
     $.ajax({
@@ -303,12 +320,15 @@ This will return the results ordered by the product label. You can also tell the
     ```
 === "jQuery"
     ```javascript
-    var params = {
+    var paramsObj = {
         'sort': '-product.label'
     };
+    var params;
 
     if(options.meta.prefix) { // returned from OPTIONS call
-        params[options.meta.prefix] = params;
+        params[options.meta.prefix] = paramsObj;
+    } else {
+        params = paramsObj
     }
 
     $.ajax({
@@ -329,12 +349,15 @@ Sorting by several keys is also possible if they are separated by a comma:
     ```
 === "jQuery"
     ```javascript
-    var params = {
+    var paramsObj = {
         'sort': '-product.status,product.id'
     };
+    var params;
 
     if(options.meta.prefix) { // returned from OPTIONS call
-        params[options.meta.prefix] = params;
+        params[options.meta.prefix] = paramsObj;
+    } else {
+        params = paramsObj
     }
 
     $.ajax({
@@ -347,7 +370,7 @@ Sorting by several keys is also possible if they are separated by a comma:
     });
     ```
 
-It would sort the result set by the product status (descending) and the product ID.
+Here the result set is sorted by the product status (descending) and the product ID.
 
 !!! warning
     Don't forget to [nest the parameters](index.md#nested-parameters) if a prefix is sent in the meta data!
@@ -362,15 +385,18 @@ By default, only the first 25 items are returned if nothing else is specified. T
     ```
 === "jQuery"
     ```javascript
-    var params = {
+    var paramsObj = {
         'page': {
             'offset': 0,
             'limit': 2
         }
     };
+    var params;
 
     if(options.meta.prefix) { // returned from OPTIONS call
-        params[options.meta.prefix] = params;
+        params[options.meta.prefix] = paramsObj;
+    } else {
+        params = paramsObj
     }
 
     $.ajax({
@@ -383,13 +409,13 @@ By default, only the first 25 items are returned if nothing else is specified. T
     });
     ```
 
-Thus, you will get the first 2 items instead. If more items are available, the first response automatically contains links for navigating through the results:
+This will get only the first 2 items. If more items are available, the first response automatically contains links for navigating through the results:
 
 ```json
 "links": {
     "first": "http://localhost:8000/jsonapi/product?page%5Boffset%5D=0&page%5Blimit%5D=2",
     "prev": "http://localhost:8000/jsonapi/product?page%5Boffset%5D=0&page%5Blimit%5D=2",
-    "next": "http://localhost:8000/jsonapi/product?page%5Boffset%5D=4&page%5Blimit%5D=2",
+    "next": "http://localhost:8000/jsonapi/product?page%5Boffset%5D=2&page%5Blimit%5D=2",
     "last": "http://localhost:8000/jsonapi/product?page%5Boffset%5D=4&page%5Blimit%5D=2",
     "self": "http://localhost:8000/jsonapi/product?page%5Boffset%5D=2&page%5Blimit%5D=2"
 }
@@ -414,6 +440,9 @@ To get the next 2 items starting from the 3rd one use the *next* link from the a
     });
     ```
 
+!!! note
+    Please note that the *last* link's offset ("4" in the given example) depends on the number of products available.
+
 !!! warning
     Don't forget to [nest the parameters](index.md#nested-parameters) if a prefix is sent in the meta data!
 
@@ -429,14 +458,17 @@ If you only need the values of a few fields and want to reduce the amount of dat
     ```
 === "jQuery"
     ```javascript
-    var params = {
+    var paramsObj = {
         'fields': {
             'product': 'product.id,product.label'
         }
     };
+    var params;
 
     if(options.meta.prefix) { // returned from OPTIONS call
-        params[options.meta.prefix] = params;
+        params[options.meta.prefix] = paramsObj;
+    } else {
+        params = paramsObj
     }
 
     $.ajax({
@@ -449,7 +481,7 @@ If you only need the values of a few fields and want to reduce the amount of dat
     });
     ```
 
-The generated request will then only return the ID and label of product items:
+The generated request will then only return the ID and label of product items.
 
 !!! warning
     Don't forget to [nest the parameters](index.md#nested-parameters) if a prefix is sent in the meta data!
@@ -464,12 +496,15 @@ To minimize the number of requests, the Aimeos JSON API can add related resource
     ```
 === "jQuery"
     ```javascript
-    var params = {
+    var paramsObj = {
         'include': 'text'
     };
+    var params;
 
     if(options.meta.prefix) { // returned from OPTIONS call
-        params[options.meta.prefix] = params;
+        params[options.meta.prefix] = paramsObj;
+    } else {
+        params = paramsObj
     }
 
     $.ajax({
@@ -482,7 +517,7 @@ To minimize the number of requests, the Aimeos JSON API can add related resource
     });
     ```
 
-This returns the texts associated with the products within the same request:
+This returns the product(s) as well as the text(s) associated with the product(s) within the same request:
 
 ```json
 {
@@ -608,12 +643,15 @@ This does also work for items from the same domain that have a parent/child rela
     ```
 === "jQuery"
     ```javascript
-    var params = {
+    var paramsObj = {
         'include': 'product/property'
     };
+    var params;
 
     if(options.meta.prefix) { // returned from OPTIONS call
-        params[options.meta.prefix] = params;
+        params[options.meta.prefix] = paramsObj;
+    } else {
+        params = paramsObj
     }
 
     $.ajax({

--- a/src/frontend/jsonapi/basics.md
+++ b/src/frontend/jsonapi/basics.md
@@ -104,7 +104,7 @@ Additionally, you can use custom filters for each resource. The JSON API standar
             '>': {'product.type': 'select'}
         }
     };
-    var params;
+    var params = {};
 
     if(options.meta.prefix) { // returned from OPTIONS call
         params[options.meta.prefix] = args;
@@ -169,7 +169,7 @@ To combine several conditions into one request, you can combine two or more "com
             ]
         }
     };
-    var params;
+    var params = {};
 
     if(options.meta.prefix) { // returned from OPTIONS call
         params[options.meta.prefix] = args;
@@ -214,7 +214,7 @@ The negation is a special case because it only accepts one "compare" condition w
             ]
         }
     };
-    var params;
+    var params = {};
 
     if(options.meta.prefix) { // returned from OPTIONS call
         params[options.meta.prefix] = args;
@@ -256,7 +256,7 @@ You can also create more complicated statements by nesting them like:
             ]
         }
     };
-    var params;
+    var params = {};
 
     if(options.meta.prefix) { // returned from OPTIONS call
         params[options.meta.prefix] = args;
@@ -294,7 +294,7 @@ Additionally, you can use the sort parameter and the items keys for generic sort
     var args = {
         'sort': 'product.label'
     };
-    var params;
+    var params = {};
 
     if(options.meta.prefix) { // returned from OPTIONS call
         params[options.meta.prefix] = args;
@@ -323,7 +323,7 @@ This will return the results ordered by the product label. You can also tell the
     var args = {
         'sort': '-product.label'
     };
-    var params;
+    var params = {};
 
     if(options.meta.prefix) { // returned from OPTIONS call
         params[options.meta.prefix] = args;
@@ -352,7 +352,7 @@ Sorting by several keys is also possible if they are separated by a comma:
     var args = {
         'sort': '-product.status,product.id'
     };
-    var params;
+    var params = {};
 
     if(options.meta.prefix) { // returned from OPTIONS call
         params[options.meta.prefix] = args;
@@ -391,7 +391,7 @@ By default, only the first 25 items are returned if nothing else is specified. T
             'limit': 2
         }
     };
-    var params;
+    var params = {};
 
     if(options.meta.prefix) { // returned from OPTIONS call
         params[options.meta.prefix] = args;
@@ -463,7 +463,7 @@ If you only need the values of a few fields and want to reduce the amount of dat
             'product': 'product.id,product.label'
         }
     };
-    var params;
+    var params = {};
 
     if(options.meta.prefix) { // returned from OPTIONS call
         params[options.meta.prefix] = args;
@@ -499,7 +499,7 @@ To minimize the number of requests, the Aimeos JSON API can add related resource
     var args = {
         'include': 'text'
     };
-    var params;
+    var params = {};
 
     if(options.meta.prefix) { // returned from OPTIONS call
         params[options.meta.prefix] = args;
@@ -646,7 +646,7 @@ This does also work for items from the same domain that have a parent/child rela
     var args = {
         'include': 'product/property'
     };
-    var params;
+    var params = {};
 
     if(options.meta.prefix) { // returned from OPTIONS call
         params[options.meta.prefix] = args;

--- a/src/frontend/jsonapi/basics.md
+++ b/src/frontend/jsonapi/basics.md
@@ -69,7 +69,7 @@ All GET requests will return a JSON object with the structure defined by [jsonap
 }
 ```
 
-The **"meta"** section will always contain a "total" property on success. It's value is the number of items found in total for the current search filter.
+The **"meta"** section will always contain a "total" property on success. Its value is the number of items found in total for the current search filter.
 
 In the **"links"** section, all necessary links for navigating through the result set are listed including the link for the current request.
 
@@ -99,7 +99,7 @@ Additionally, you can use custom filters for each resource. The JSON API standar
     ```
 === "jQuery"
     ```javascript
-    var paramsObj = {
+    var args = {
         'filter': {
             '>': {'product.type': 'select'}
         }
@@ -107,9 +107,9 @@ Additionally, you can use custom filters for each resource. The JSON API standar
     var params;
 
     if(options.meta.prefix) { // returned from OPTIONS call
-        params[options.meta.prefix] = paramsObj;
+        params[options.meta.prefix] = args;
     } else {
-        params = paramsObj;
+        params = args;
     }
 
     $.ajax({
@@ -161,7 +161,7 @@ To combine several conditions into one request, you can combine two or more "com
     ```
 === "jQuery"
     ```javascript
-    var paramsObj = {
+    var args = {
         'filter': {
             '&&': [
                 {'>': {'product.type': 'select'}},
@@ -172,9 +172,9 @@ To combine several conditions into one request, you can combine two or more "com
     var params;
 
     if(options.meta.prefix) { // returned from OPTIONS call
-        params[options.meta.prefix] = paramsObj;
+        params[options.meta.prefix] = args;
     } else {
-        params = paramsObj;
+        params = args;
     }
 
     $.ajax({
@@ -207,7 +207,7 @@ The negation is a special case because it only accepts one "compare" condition w
     ```
 === "jQuery"
     ```javascript
-    var paramsObj = {
+    var args = {
         'filter': {
             '!': [
                 {'=~': {'product.code': 'demo-s'}}
@@ -217,9 +217,9 @@ The negation is a special case because it only accepts one "compare" condition w
     var params;
 
     if(options.meta.prefix) { // returned from OPTIONS call
-        params[options.meta.prefix] = paramsObj;
+        params[options.meta.prefix] = args;
     } else {
-        params = paramsObj;
+        params = args;
     }
 
     $.ajax({
@@ -243,7 +243,7 @@ You can also create more complicated statements by nesting them like:
     ```
 === "jQuery"
     ```javascript
-    var paramsObj = {
+    var args = {
         'filter': {
             '&&': [
                 {'!': [
@@ -259,9 +259,9 @@ You can also create more complicated statements by nesting them like:
     var params;
 
     if(options.meta.prefix) { // returned from OPTIONS call
-        params[options.meta.prefix] = paramsObj;
+        params[options.meta.prefix] = args;
     } else {
-        params = paramsObj;
+        params = args;
     }
 
     $.ajax({
@@ -291,15 +291,15 @@ Additionally, you can use the sort parameter and the items keys for generic sort
     ```
 === "jQuery"
     ```javascript
-    var paramsObj = {
+    var args = {
         'sort': 'product.label'
     };
     var params;
 
     if(options.meta.prefix) { // returned from OPTIONS call
-        params[options.meta.prefix] = paramsObj;
+        params[options.meta.prefix] = args;
     } else {
-        params = paramsObj;
+        params = args;
     }
 
     $.ajax({
@@ -320,15 +320,15 @@ This will return the results ordered by the product label. You can also tell the
     ```
 === "jQuery"
     ```javascript
-    var paramsObj = {
+    var args = {
         'sort': '-product.label'
     };
     var params;
 
     if(options.meta.prefix) { // returned from OPTIONS call
-        params[options.meta.prefix] = paramsObj;
+        params[options.meta.prefix] = args;
     } else {
-        params = paramsObj
+        params = args
     }
 
     $.ajax({
@@ -349,15 +349,15 @@ Sorting by several keys is also possible if they are separated by a comma:
     ```
 === "jQuery"
     ```javascript
-    var paramsObj = {
+    var args = {
         'sort': '-product.status,product.id'
     };
     var params;
 
     if(options.meta.prefix) { // returned from OPTIONS call
-        params[options.meta.prefix] = paramsObj;
+        params[options.meta.prefix] = args;
     } else {
-        params = paramsObj
+        params = args
     }
 
     $.ajax({
@@ -385,7 +385,7 @@ By default, only the first 25 items are returned if nothing else is specified. T
     ```
 === "jQuery"
     ```javascript
-    var paramsObj = {
+    var args = {
         'page': {
             'offset': 0,
             'limit': 2
@@ -394,9 +394,9 @@ By default, only the first 25 items are returned if nothing else is specified. T
     var params;
 
     if(options.meta.prefix) { // returned from OPTIONS call
-        params[options.meta.prefix] = paramsObj;
+        params[options.meta.prefix] = args;
     } else {
-        params = paramsObj
+        params = args
     }
 
     $.ajax({
@@ -458,7 +458,7 @@ If you only need the values of a few fields and want to reduce the amount of dat
     ```
 === "jQuery"
     ```javascript
-    var paramsObj = {
+    var args = {
         'fields': {
             'product': 'product.id,product.label'
         }
@@ -466,9 +466,9 @@ If you only need the values of a few fields and want to reduce the amount of dat
     var params;
 
     if(options.meta.prefix) { // returned from OPTIONS call
-        params[options.meta.prefix] = paramsObj;
+        params[options.meta.prefix] = args;
     } else {
-        params = paramsObj
+        params = args
     }
 
     $.ajax({
@@ -496,15 +496,15 @@ To minimize the number of requests, the Aimeos JSON API can add related resource
     ```
 === "jQuery"
     ```javascript
-    var paramsObj = {
+    var args = {
         'include': 'text'
     };
     var params;
 
     if(options.meta.prefix) { // returned from OPTIONS call
-        params[options.meta.prefix] = paramsObj;
+        params[options.meta.prefix] = args;
     } else {
-        params = paramsObj
+        params = args
     }
 
     $.ajax({
@@ -517,7 +517,7 @@ To minimize the number of requests, the Aimeos JSON API can add related resource
     });
     ```
 
-This returns the product(s) as well as the text(s) associated with the product(s) within the same request:
+This returns the product or products as well as the texts associated with the products within the same request:
 
 ```json
 {
@@ -643,15 +643,15 @@ This does also work for items from the same domain that have a parent/child rela
     ```
 === "jQuery"
     ```javascript
-    var paramsObj = {
+    var args = {
         'include': 'product/property'
     };
     var params;
 
     if(options.meta.prefix) { // returned from OPTIONS call
-        params[options.meta.prefix] = paramsObj;
+        params[options.meta.prefix] = args;
     } else {
-        params = paramsObj
+        params = args
     }
 
     $.ajax({

--- a/src/frontend/jsonapi/basics.md
+++ b/src/frontend/jsonapi/basics.md
@@ -415,7 +415,7 @@ This will get only the first 2 items. If more items are available, the first res
 "links": {
     "first": "http://localhost:8000/jsonapi/product?page%5Boffset%5D=0&page%5Blimit%5D=2",
     "prev": "http://localhost:8000/jsonapi/product?page%5Boffset%5D=0&page%5Blimit%5D=2",
-    "next": "http://localhost:8000/jsonapi/product?page%5Boffset%5D=2&page%5Blimit%5D=2",
+    "next": "http://localhost:8000/jsonapi/product?page%5Boffset%5D=4&page%5Blimit%5D=2",
     "last": "http://localhost:8000/jsonapi/product?page%5Boffset%5D=4&page%5Blimit%5D=2",
     "self": "http://localhost:8000/jsonapi/product?page%5Boffset%5D=2&page%5Blimit%5D=2"
 }

--- a/src/frontend/jsonapi/basket-addresses.md
+++ b/src/frontend/jsonapi/basket-addresses.md
@@ -1,8 +1,8 @@
-By default, you can add a billing and delivery address to the basket. While the delivery address is optional, setting the billing address is almost always mandatory.
+By default you can add a billing and delivery address to the basket. While the delivery address is optional, setting the billing address is almost always mandatory.
 
 # Add addresses
 
-To add one or more addresses, you have to pass the data including the "id" and the attributes in a POST request to the server. The "id" is in that case the type of the address, i.e. "payment" for the billing address and "delivery" for the corresponding address.
+To add one or more addresses you have to pass the data including the "id" and the attributes in a POST request to the server. The "id" is in that case the type of the address, i.e. "payment" for the billing address and "delivery" for the corresponding address.
 
 There are some address attributes that are required when adding or replacing an address:
 
@@ -12,7 +12,7 @@ There are some address attributes that are required when adding or replacing an 
 * order.base.address.languageid (language the customer prefers)
 * order.base.address.email (account e-mail address)
 
-The request for creating a new address in the basket could look like:
+The request for creating a new address in the basket could look like this:
 
 === "CURL"
     ```bash
@@ -176,18 +176,17 @@ The response will then contain an additional "relationships" section in the bask
 }
 ```
 
-Depending on the activated basket plugins, the content of the response can be modified more than that. Especially, as the address is often the basis for the available delivery options.
+Depending on the activated basket plugins, the content of the response can be modified more than that. Especially since the address is often the basis for the available delivery options.
 
 # Delete addresses
 
-You can also remove addresses from the basket again by using a DELETE request to the URL of the address in the basket. In our example above, the URL is:
+You can also remove addresses from the basket again by using a DELETE request to the URL of the address in the basket. In our example above the URL is:
 
 ```
 http://localhost:8000/jsonapi/basket?id=default&related=address&relatedid=payment
 ```
 
 The DELETE request can be constructed in that way:
-
 
 === "CURL"
     ```bash
@@ -214,4 +213,4 @@ The DELETE request can be constructed in that way:
     });
     ```
 
-This request will remove the address entry from the basket and the response won't contain the address  in the "included" section as well the corresponding "relationships" entry any more.
+This request will remove the address entry from the basket, and the response won't contain the address in the "included" section neither the corresponding "relationships" entry anymore.

--- a/src/frontend/jsonapi/basket-coupons.md
+++ b/src/frontend/jsonapi/basket-coupons.md
@@ -1,6 +1,6 @@
 # Add coupons
 
-Coupon (or voucher) codes can be added to the basket by using the "basket/coupon" URL that is sent in every basket response. The data objects only need the code passed in the "id" parameter like this:
+Coupon (or voucher) codes can be added to the basket by using the "basket/coupon" URL that is sent with every basket response. The data objects only need the code passed in the "id" parameter like this:
 
 === "CURL"
     ```bash
@@ -100,7 +100,7 @@ If a coupon code does require one or more prerequisites and they aren't matched,
 
 # Delete coupons
 
-Removing coupons from the basket is done by using a DELETE request to the URL of the coupon entry in the basket. In our example above, the URL is:
+Removing coupons from the basket is done by using a DELETE request to the URL of the coupon entry in the basket. In our example above the URL is:
 
 ```
 http://localhost:8000/jsonapi/basket?id=default&related=coupon&relatedid=fixed

--- a/src/frontend/jsonapi/basket-products.md
+++ b/src/frontend/jsonapi/basket-products.md
@@ -85,7 +85,7 @@ To add a simple product to the basket may look like this:
     });
     ```
 
-Then, the response will contain an additional "relationships" entry in the basket data that points to the order product entry in the "included" section:
+Then the response will contain an additional "relationships" entry in the basket data that points to the order product entry in the "included" section:
 
 ```json
 {
@@ -163,7 +163,7 @@ Then, the response will contain an additional "relationships" entry in the baske
 
 ## Selection products
 
-For selection products, you have to pass the ID of the selection product and one ID for each variant attribute type assiged to the article, so the concrete article can be identified. If you have a shirt as selection product which includes two colors, your product structure would look like this one:
+For selection products, you have to pass the ID of the selection product and one ID for each variant attribute type assigned to the article, so the concrete article can be identified. If you have a shirt as selection product which includes two colors, your product structure would look like this one:
 
 Shirt product (product.type: select)
 
@@ -174,9 +174,9 @@ Shirt product (product.type: select)
     * variant attribute type: color
     * variant attribute code: beige
 
-There's some documentation available how to [create selection products](../../manual/products.md#selections).
+There's some documentation available on how to [create selection products](../../manual/products.md#selections).
 
-You will get the selection product including its variant articles their attributes if you add *&include=product,attribute* to the product URL:
+You will get the selection product including its variant attributes if you add *&include=product,attribute* to the product URL:
 
 ```json
 {
@@ -346,7 +346,7 @@ is **variant** in the included articles. Pass the ID of the variant attribute th
     ```
 
 !!! tip
-    The response for selection products tends to get big if all articles, texts, images and attributes are included. You can limit the returned fields using the [fields parameter](basics.md#return-specific-fields-only) and this work for the relationship fields too if you use *&fields[product/lists]=product.lists.type* for example to return the type of the product resp. attribute relationship only.
+    The response for selection products tends to get big if all articles, texts, images and attributes are included. You can limit the returned fields using the [fields parameter](basics.md#return-specific-fields-only). This works for the relationship fields, too, if you use e.g. *&fields[product/lists]=product.lists.type* to return the type of the product resp. attribute relationship only.
 
 ## Configurable options
 
@@ -426,7 +426,7 @@ The response contains two configurable attributes with the IDs "2" and "6" becau
 
 ```data['relationships']['attribute']['data'][*]['attributes']['product.lists.type']```
 
-is **config**. Now, add all of those configurable attribute IDs and their quantities (`"<id>"': <qty>` pairs) the user selected to the request. The example below adds the "large print" option with a quantity of "2" to the basket product:
+is **config**. Now add all of those configurable attribute IDs and their quantities (`"<id>"': <qty>` pairs) the user selected to the request. The example below adds the "large print" option with a quantity of "2" to the basket product:
 
 === "CURL"
     ```bash
@@ -575,9 +575,7 @@ Now we have three possible custom attributes with the IDs "3", "4" and "7" becau
 
 ```data['relationships']['attribute']['data'][*]['attributes']['product.lists.type']```
 
-is **custom**. To add all of those configurable attribute IDs and their values (`"<id>": "<value>"` pairs) the user entered use a request like that:
-
-The IDs and values of custom attribute must be passed as key/value pairs:
+is **custom**. To add all of those configurable attribute IDs and their values (`"<id>": "<value>"` pairs) the user entered use a request like this passing the IDs and values of the **custom** attributes as key/value pairs:
 
 === "CURL"
     ```bash
@@ -628,18 +626,18 @@ The IDs and values of custom attribute must be passed as key/value pairs:
 
 # Edit products
 
-To edit already added products in the basket, you can send a PATCH request to the URL listed in the links section of the ordered product. In the response before it's:
+To edit already added products in the basket, you can send a PATCH request to the URL listed in the links section of the ordered product. Based on a response URL like this:
 
 ```
 http://localhost:8000/jsonapi/basket?id=default&related=product&relatedid=0
 ```
 
-Based on this URL, you can change the quanity of the product in the basket:
+you can change the quanity of the product in the basket:
 
 quantity
 : Amount of products that should be bought
 
-Editing products in the basket should be similar to this one:
+Editing products in the basket should be similar to this:
 
 === "CURL"
     ```bash
@@ -755,8 +753,7 @@ The PATCH requests will change primarily the product data in the basket. Dependi
 }
 ```
 
-
-The response only contains the updated product and basket details in this example.
+In this example, the response only contains the updated product and basket details.
 
 # Delete products
 

--- a/src/frontend/jsonapi/basket-products.md
+++ b/src/frontend/jsonapi/basket-products.md
@@ -163,7 +163,7 @@ Then the response will contain an additional "relationships" entry in the basket
 
 ## Selection products
 
-For selection products, you have to pass the ID of the selection product and one ID for each variant attribute type assigned to the article, so the concrete article can be identified. If you have a shirt as selection product which includes two colors, your product structure would look like this one:
+For selection products you have to pass the ID of the selection product and one ID for each variant attribute type assigned to the article, so the concrete article can be identified. If you have a shirt as selection product which includes two colors, your product structure would look like this one:
 
 Shirt product (product.type: select)
 
@@ -753,11 +753,11 @@ The PATCH requests will change primarily the product data in the basket. Dependi
 }
 ```
 
-In this example, the response only contains the updated product and basket details.
+In this example the response only contains the updated product and basket details.
 
 # Delete products
 
-Removing product entries from the basket is done by using a DELETE request to the URL of the ordered product. In our example before, the URL is:
+Removing product entries from the basket is done by using a DELETE request to the URL of the ordered product. In our current example the URL is:
 
 ```
 http://localhost:8000/jsonapi/basket?id=default&related=product&relatedid=0
@@ -791,4 +791,4 @@ The code for the DELETE request itself is fairly simple:
     ```
 
 
-Afterwards, the product in the basket identified by the URL is removed from the basket. Depending on the activated basket plugins, more changes might have happened.
+Afterwards the product in the basket identified by the URL is removed from the basket. Depending on the activated basket plugins, more changes might have happened.

--- a/src/frontend/jsonapi/basket-services.md
+++ b/src/frontend/jsonapi/basket-services.md
@@ -390,18 +390,18 @@ The response to this request would be similar to this:
 It contains an additional "relationships" entry for the basket which points to the basket service entry in the "included" section.
 
 !!! note
-    If you perform the same request again, **existing options** in the basket are **NOT overwritten** but an additional option added! Thus, you can add several delivery or payment options in one order.
+    If you perform the same request again, **existing options** in the basket are **NOT overwritten** but an additional option added! Thus you can add several delivery or payment options in one order.
 
 ## Passing additonal data
 
-The "attributes" section in "data" can contain additional key/value pairs whose values are entered by the customer. Here, the pickup time and location is passed, and e.g. for direct debit payment related data must be passed. The available keys are listed in the "meta" section of the "basket/service" link of each entry returned by the service response:
+The "attributes" section in "data" can contain additional key/value pairs whose values are entered by the customer. Here the "pickup time" and "location" are passed. The available keys are listed in the "meta" section of the "basket/service" link of each entry returned by the service response:
 
 ```json
 "meta": {
     "time.hourminute": {
         "code": "time.hourminute",
         "type": "time",
-        "label": "Delivery time",
+        "label": "Pick-up time",
         "public": true,
         "default": "07:15",
         "required": true

--- a/src/frontend/jsonapi/basket-services.md
+++ b/src/frontend/jsonapi/basket-services.md
@@ -1,25 +1,28 @@
-Most of the time, you want to offer some shipping and payment options to your customers or at least one. Even if you don't show the shipping or payment options, you need to add it to the basket so the process after creating the order continues as expected.
+Most of the time you want to offer some shipping and/or payment options to your customers. Even if you don't show the shipping or payment options, you need to add it to the basket so the process after creating the order continues as expected.
 
 # List options
 
-At first, you need to get the available delivery and payment options from the services resource URL listed in the OPTIONS request. With URL, you can query for the available services, either all together in one request or separated by their type ("delivery" or "payment"). The example code below will return all payment options:
+At first you need to get the available delivery and payment options from the services resource URL listed in the OPTIONS request. With that URL you can query for the available services, either all together in one request or separated by their type ("delivery" or "payment"). The example code below will return all payment options:
 
 === "CURL"
     ```bash
     curl -b cookies.txt -c cookies.txt \
-    -X GET 'http://localhost:8000/jsonapi/service?filter[cs_type]=delivery&include=text,price,media'
+    -X GET 'http://localhost:8000/jsonapi/service?filter[cs_type]=payment&include=text,price,media'
     ```
 === "jQuery"
     ```javascript
-    var params = {
+    var args = {
         'filter': {
-            'cs_type': 'delivery' // or "delivery" (optional)
+            'cs_type': 'payment' // or "delivery" (optional)
         },
         'include': 'text,price,media'
     };
+    var params;
 
     if(options.meta.prefix) { // returned from OPTIONS call
-        params[options.meta.prefix] = params;
+        params[options.meta.prefix] = args;
+    } else {
+        params = args;
     }
 
     $.ajax({
@@ -32,7 +35,7 @@ At first, you need to get the available delivery and payment options from the se
     });
     ```
 
-This returns the list of payment or delivery options (or both if the "filter" parameter is omitted) including the associated texts, price and images due to the "included" parameter:
+This returns the list of payment or delivery options (or both if the "filter" parameter is omitted) including the associated texts, prices and images due to the "included" parameter:
 
 ```json
 {
@@ -221,18 +224,18 @@ This returns the list of payment or delivery options (or both if the "filter" pa
 
 # Add delivery/payment
 
-To add a service to the basket, you need the "basket/service" URL from the service resource response. In our previous example, the URL of the first delivery option that would add this service to the basket was:
+To add a service to the basket you need the "basket/service" URL from the service resource response. In our previous example, the URL of the first delivery option that would add this service to the basket is:
 
 ```
 http://localhost:8000/jsonapi/basket?id=default&related=service&relatedid=delivery
 ```
 
-To add this service as delivery option in the current basket, you should use:
+To add this service as delivery option to the current basket you should use:
 
 === "CURL"
     ```bash
     curl -b cookies.txt -c cookies.txt \
-    -X POST 'http://localhost:8000/jsonapi/basket?id=default&related=service&relatedid=delivery&_token=uP2PvRc9JbLe3uk0zADb8wktD8m620WwM4ZI6BiV' \
+    -X POST 'http://localhost:8000/jsonapi/basket?id=default&related=service&relatedid=delivery&_token=...' \
     -H 'Content-Type: application/json' \
     -d '{"data": [{
         "id": "delivery",
@@ -272,7 +275,7 @@ To add this service as delivery option in the current basket, you should use:
     });
     ```
 
-It's important to add the **id: "delivery"** (or **"payment"**) and the service ID in the attributes section of the parameters sent to the server.  The value for "id" is the service type while the value for "service.id" must be the ID of the service option that should be added as delivery or payment entry to the basket.
+It's important to add the **id: "delivery"** (or **"payment"**) and the service ID in the attributes section of the parameters sent to the server. The value for "id" is the service type while the value for "service.id" must be the ID of the service option that should be added as delivery or payment entry to the basket.
 
 The response to this request would be similar to this:
 
@@ -391,7 +394,7 @@ It contains an additional "relationships" entry for the basket which points to t
 
 ## Passing additonal data
 
-The "attributes" section in "data" can contain additional key/value pairs whose values are entered by the customer. Here, the pickup time and location is passed and e.g. for direct debit payment related data must be passed. The available keys are listed in the "meta" section of the "basket/service" link of each entry returned by the service response:
+The "attributes" section in "data" can contain additional key/value pairs whose values are entered by the customer. Here, the pickup time and location is passed, and e.g. for direct debit payment related data must be passed. The available keys are listed in the "meta" section of the "basket/service" link of each entry returned by the service response:
 
 ```json
 "meta": {
@@ -419,7 +422,7 @@ The "attributes" section in "data" can contain additional key/value pairs whose 
 
 Only values for these keys will be accepted and if the "required" property is true, they must be passed in the request!
 
-Each of these additional service attributes contains a type property, which can be one of these:
+Each of these additional service attributes contains a type property which can be one of these:
 
 boolean
 : True/false value (input of type "checkbox")
@@ -476,7 +479,7 @@ The additional service attributes are then stored in the "attribute" section of 
 
 # Delete services
 
-Delivery or payment options added to the basket can also be removed again. For this, you need the URL from the basket service entry that is returned in the basket response. For the example above, it's:
+Delivery or payment options added to the basket can also be removed again. For this you need the URL from the basket service entry that is returned in the basket response. For the example above it is:
 
 ```
 http://localhost:8000/jsonapi/basket?id=default&related=service&relatedid=delivery

--- a/src/frontend/jsonapi/basket-services.md
+++ b/src/frontend/jsonapi/basket-services.md
@@ -17,7 +17,7 @@ At first you need to get the available delivery and payment options from the ser
         },
         'include': 'text,price,media'
     };
-    var params;
+    var params = {};
 
     if(options.meta.prefix) { // returned from OPTIONS call
         params[options.meta.prefix] = args;

--- a/src/frontend/jsonapi/baskets.md
+++ b/src/frontend/jsonapi/baskets.md
@@ -35,7 +35,6 @@ This will return a response like:
 }
 ```
 
-
 The "csrf" section in "meta" will be important when you want to modify the basket. Each response will contain such a "csrf" section if the host application supports tokens against cross-site request forgery attacks. If available, you need to send them with every DELETE, PATCH and POST request.
 
 !!! warning

--- a/src/frontend/jsonapi/baskets.md
+++ b/src/frontend/jsonapi/baskets.md
@@ -39,11 +39,11 @@ This will return a response like:
 The "csrf" section in "meta" will be important when you want to modify the basket. Each response will contain such a "csrf" section if the host application supports tokens against cross-site request forgery attacks. If available, you need to send them with every DELETE, PATCH and POST request.
 
 !!! warning
-    Don't take the resource URLs in the OPTIONS response as granted! They will change depending on the routes and the application. Thus, your client needs the OPTIONS URL of the JSON REST API as configuration parameter. It's response will define the next possibilities.
+    Don't take the resource URLs in the OPTIONS response as granted! They will change depending on the routes and the application. Thus your client needs the OPTIONS URL of the JSON REST API as configuration parameter. Its response will define the next possibilities.
 
 # Fetch the basket
 
-To retrieve the current basket content, you need to send a GET request to the basket resource like this:
+To retrieve the current basket content you need to send a GET request to the basket resource like this:
 
 === "CURL"
     ```bash
@@ -61,7 +61,7 @@ To retrieve the current basket content, you need to send a GET request to the ba
     });
     ```
 
-If the basket is empty, it will return only the basic basket properties but no products, addresses, service items or coupons. Important is that the same session cookie is sent with each request. Otherwise an empty basket is returned for every request regardless of which action you've performed before. The response would be for example:
+If the basket is empty, it will return only the basic basket properties but no products, addresses, service items or coupons. It is very important that the same session cookie is sent with each request. Otherwise an empty basket is returned for every request regardless of which action you've performed before. The response would be for example:
 
 ```json
 {
@@ -70,9 +70,9 @@ If the basket is empty, it will return only the basic basket properties but no p
         "prefix": null,
         "content-baseurl": "/",
         "csrf": {
-                "name": "_token",
-                "value": "..."
-            }
+            "name": "_token",
+            "value": "..."
+        }
     },
     "links": {
         "self": {
@@ -124,7 +124,7 @@ There are three values that you can update using a PATCH request to the basket:
 * order.base.comment (customer comment for this order)
 * order.base.customerref (own reference of the customer for this order)
 
-The update the basket, you have to use the "self" link from a previous GET request:
+To update the basket you have to use the "self" link from a previous GET request:
 
 === "CURL"
     ```bash
@@ -171,7 +171,7 @@ The response will be the same as for the GET request but the attributes are upda
 
 # Clear the basket
 
-Removing all items and properties from the basket (effectively wiping out the basket content) is done by doing a DELETE request to the basket resource:
+Removing all items and properties from the basket (effectively wiping out the basket content) is done by sending a DELETE request to the basket resource:
 
 === "CURL"
     ```bash

--- a/src/frontend/jsonapi/baskets.md
+++ b/src/frontend/jsonapi/baskets.md
@@ -1,4 +1,4 @@
-To be able to retrieve the basket, you need the basket resource endpoint from the OPTIONS request. Depending on the used routes it might be something like:
+To be able to retrieve the basket, you need the basket resource endpoint from the OPTIONS request. Depending on the used routes it might be something like this:
 
 === "CURL"
     ```bash
@@ -61,7 +61,7 @@ To retrieve the current basket content, you need to send a GET request to the ba
     });
     ```
 
-If the basket is empty, it will return only the basic basket properties but no products, addresses, service items or coupons. Important is that the same session cookie is sent with each request. Otherwise, an empty basket is returned for every request, regardless of which action you've performed before. The response would be for example:
+If the basket is empty, it will return only the basic basket properties but no products, addresses, service items or coupons. Important is that the same session cookie is sent with each request. Otherwise an empty basket is returned for every request regardless of which action you've performed before. The response would be for example:
 
 ```json
 {
@@ -120,7 +120,7 @@ If the basket is empty, it will return only the basic basket properties but no p
 
 There are three values that you can update using a PATCH request to the basket:
 
-* order.base.customerid (ID of the customers to show the order in their account history)
+* order.base.customerid (ID of the customer to show the order in their account history)
 * order.base.comment (customer comment for this order)
 * order.base.customerref (own reference of the customer for this order)
 

--- a/src/frontend/jsonapi/baskets.md
+++ b/src/frontend/jsonapi/baskets.md
@@ -38,7 +38,7 @@ This will return a response like:
 The "csrf" section in "meta" will be important when you want to modify the basket. Each response will contain such a "csrf" section if the host application supports tokens against cross-site request forgery attacks. If available, you need to send them with every DELETE, PATCH and POST request.
 
 !!! warning
-    Don't take the resource URLs in the OPTIONS response as granted! They will change depending on the routes and the application. Thus your client needs the OPTIONS URL of the JSON REST API as configuration parameter. Its response will define the next possibilities.
+    Don't take the resource URLs in the OPTIONS response as granted! They will change depending on the routes and the application. Thus, your client needs the OPTIONS URL of the JSON REST API as configuration parameter. Its response will define the next possibilities.
 
 # Fetch the basket
 
@@ -119,7 +119,7 @@ If the basket is empty, it will return only the basic basket properties but no p
 
 There are three values that you can update using a PATCH request to the basket:
 
-* order.base.customerid (ID of the customer to show the order in their account history)
+* order.base.customerid (ID of the customer to show the order in her/his account history)
 * order.base.comment (customer comment for this order)
 * order.base.customerref (own reference of the customer for this order)
 

--- a/src/frontend/jsonapi/catalog.md
+++ b/src/frontend/jsonapi/catalog.md
@@ -271,7 +271,7 @@ In addition to the generic filter possibilities, the product lists can be sorted
 === "jQuery"
     ```javascript
     var args = {'sort': '-ctime'};
-    var params;
+    var params = {};
 
     if(options.meta.prefix) { // returned from OPTIONS call
         params[options.meta.prefix] = args;
@@ -306,7 +306,7 @@ If you offer users a search field for products, you have to add the entered text
             'f_search': 'demo'
         }
     };
-    var params;
+    var params = {};
 
     if(options.meta.prefix) { // returned from OPTIONS call
         params[options.meta.prefix] = args;
@@ -339,7 +339,7 @@ To enable users to filter products by price, you need to use the *index.price:va
             '<': {'index.price:value("EUR")': 99.50}
         }
     };
-    var params;
+    var params = {};
 
     if(options.meta.prefix) { // returned from OPTIONS call
         params[options.meta.prefix] = args;
@@ -375,7 +375,7 @@ Usually, you want to filter for a price range, so you need to pass an upper and 
             ]
         }
     };
-    var params;
+    var params = {};
 
     if(options.meta.prefix) { // returned from OPTIONS call
         params[options.meta.prefix] = args;
@@ -404,7 +404,7 @@ To display the category tree, you have to use the "catalog" resource returned by
 === "jQuery"
     ```javascript
     var args = {'include': 'catalog,media,text'};
-    var params;
+    var params = {};
 
     if(options.meta.prefix) { // returned from OPTIONS call
         params[options.meta.prefix] = args;
@@ -514,7 +514,7 @@ To get the products for a category, use the *f_catid* filter parameter:
             'f_catid': '1'
         }
     };
-    var params;
+    var params = {};
 
     if(options.meta.prefix) { // returned from OPTIONS call
         params[options.meta.prefix] = args;
@@ -546,7 +546,7 @@ By default, all the found products use "default" as the category list type. You 
             'f_listtype': 'promotion'
         }
     };
-    var params;
+    var params = {};
 
     if(options.meta.prefix) { // returned from OPTIONS call
         params[options.meta.prefix] = args;
@@ -575,7 +575,7 @@ The product attributes for building the faceted search can be retrieved using th
 === "jQuery"
     ```javascript
     var args = {'include': 'media,text'};
-    var params;
+    var params = {};
 
     if(options.meta.prefix) { // returned from OPTIONS call
         params[options.meta.prefix] = args;
@@ -683,7 +683,7 @@ If the user selects one or more of the attributes, you can get the corresponding
             'f_attrid': ['1','3']
         }
     };
-    var params;
+    var params = {};
 
     if(options.meta.prefix) { // returned from OPTIONS call
         params[options.meta.prefix] = args;
@@ -714,7 +714,7 @@ Instead of *f_attrid* which combines all attributes with an **AND** condition, y
             'f_optid': ['1','3']
         }
     };
-    var params;
+    var params = {};
 
     if(options.meta.prefix) { // returned from OPTIONS call
         params[options.meta.prefix] = args;
@@ -748,7 +748,7 @@ Or you can use *f_oneid* with pairs of attribute types and list of attribute IDs
             }
         }
     };
-    var params;
+    var params = {};
 
     if(options.meta.prefix) { // returned from OPTIONS call
         params[options.meta.prefix] = args;
@@ -777,7 +777,7 @@ To fetch the suppliers for building the supplier facet, use the "supplier" resou
 === "jQuery"
     ```javascript
     var args = {'include': 'media,text'};
-    var params;
+    var params = {};
 
     if(options.meta.prefix) { // returned from OPTIONS call
         params[options.meta.prefix] = args;
@@ -879,7 +879,7 @@ If the user selects a supplier, you can get the corresponding products by adding
             'f_supid': '1'
         }
     };
-    var params;
+    var params = {};
 
     if(options.meta.prefix) { // returned from OPTIONS call
         params[options.meta.prefix] = args;
@@ -912,7 +912,7 @@ You can get the attribute counts by using the **aggregate** key and the correspo
 === "jQuery"
     ```javascript
     var args = {'aggregate': 'index.attribute.id'};
-    var params;
+    var params = {};
 
     if(options.meta.prefix) { // returned from OPTIONS call
         params[options.meta.prefix] = args;
@@ -956,7 +956,7 @@ In the same way you can get the product counts for the categories by using the *
 === "jQuery"
     ```javascript
     var args = {'aggregate': 'index.catalog.id'};
-    var params;
+    var params = {};
 
     if(options.meta.prefix) { // returned from OPTIONS call
         params[options.meta.prefix] = args;
@@ -998,7 +998,7 @@ To get the product counts for the suppliers, use the **aggregate** key and the c
 === "jQuery"
     ```javascript
     var args = {'aggregate': 'index.supplier.id'};
-    var params;
+    var params = {};
 
     if(options.meta.prefix) { // returned from OPTIONS call
         params[options.meta.prefix] = args;
@@ -1044,7 +1044,7 @@ If you don't fetch the stock levels together with the products using *&include=s
             's_prodcode': ['ABCD']
         }
     };
-    var params;
+    var params = {};
 
     if(options.meta.prefix) { // returned from OPTIONS call
         params[options.meta.prefix] = args;
@@ -1101,7 +1101,7 @@ If the shop has different warehouses or local stores where customers can pick up
             's_stocktype': 'berlin'
         }
     };
-    var params;
+    var params = {};
 
     if(options.meta.prefix) { // returned from OPTIONS call
         params[options.meta.prefix] = args;

--- a/src/frontend/jsonapi/catalog.md
+++ b/src/frontend/jsonapi/catalog.md
@@ -81,7 +81,7 @@ curl -X GET 'http://localhost:8000/jsonapi/product?include=attribute,media,price
         "links": {
             "self": {
                 "href": "http:\/\/localhost:8000\/jsonapi\/product\/13",
-                "allow": ['GET']
+                "allow": ["GET"]
             },
             "basket\/product": {
                 "href": "http:\/\/localhost:8000\/jsonapi\/basket\/default\/product",
@@ -270,13 +270,13 @@ Additional to the generic filter possibilities, the product lists can be sorted 
     ```
 === "jQuery"
     ```javascript
-    var paramsObj = {'sort': '-ctime'};
+    var args = {'sort': '-ctime'};
     var params;
 
     if(options.meta.prefix) { // returned from OPTIONS call
-        params[options.meta.prefix] = paramsObj;
+        params[options.meta.prefix] = args;
     } else {
-        params = paramsObj;
+        params = args;
     }
 
     $.ajax({
@@ -301,7 +301,7 @@ If you offer users a search field for products, you have to add the entered text
     ```
 === "jQuery"
     ```javascript
-    var paramsObj = {
+    var args = {
         'filter': {
             'f_search': 'demo'
         }
@@ -309,9 +309,9 @@ If you offer users a search field for products, you have to add the entered text
     var params;
 
     if(options.meta.prefix) { // returned from OPTIONS call
-        params[options.meta.prefix] = paramsObj;
+        params[options.meta.prefix] = args;
     } else {
-        params = paramsObj;
+        params = args;
     }
 
     $.ajax({
@@ -334,7 +334,7 @@ To enable users to filter products by price, you need to use the *index.price:va
     ```
 === "jQuery"
     ```javascript
-    var paramsObj = {
+    var args = {
         'filter': {
             '<': {'index.price:value("EUR")': 99.50}
         }
@@ -342,9 +342,9 @@ To enable users to filter products by price, you need to use the *index.price:va
     var params;
 
     if(options.meta.prefix) { // returned from OPTIONS call
-        params[options.meta.prefix] = paramsObj;
+        params[options.meta.prefix] = args;
     } else {
-        params = paramsObj;
+        params = args;
     }
 
     $.ajax({
@@ -367,7 +367,7 @@ Usually, you want to filter for a price range, so you need to pass an upper and 
     ```
 === "jQuery"
     ```javascript
-    var paramsObj = {
+    var args = {
         'filter': {
             '&&': [
                 {'>': {'index.price:value("EUR")': 100}},
@@ -378,9 +378,9 @@ Usually, you want to filter for a price range, so you need to pass an upper and 
     var params;
 
     if(options.meta.prefix) { // returned from OPTIONS call
-        params[options.meta.prefix] = paramsObj;
+        params[options.meta.prefix] = args;
     } else {
-        params = paramsObj;
+        params = args;
     }
 
     $.ajax({
@@ -403,13 +403,13 @@ To display the category tree, you have to use the "catalog" resource returned by
     ```
 === "jQuery"
     ```javascript
-    var paramsObj = {'include': 'catalog,media,text'};
+    var args = {'include': 'catalog,media,text'};
     var params;
 
     if(options.meta.prefix) { // returned from OPTIONS call
-        params[options.meta.prefix] = paramsObj;
+        params[options.meta.prefix] = args;
     } else {
-        params = paramsObj;
+        params = args;
     }
 
     $.ajax({
@@ -433,11 +433,11 @@ This will return the root catalog node and its direct children as well as their 
         "links": {
             "self": {
                 "href": "http:\/\/localhost:8000\/jsonapi\/catalog?id=201",
-                "allow": ['GET']
+                "allow": ["GET"]
             },
             "product": {"
                 href": "http:\/\/localhost:8000\/jsonapi\/product?filter%5Bf_catid%5D=201",
-                "allow": ['GET']
+                "allow": ["GET"]
             }
         },
         "attributes": {
@@ -463,7 +463,7 @@ This will return the root catalog node and its direct children as well as their 
         "links": {
             "self": {
                 "href": "http:\/\/localhost:8000\/jsonapi\/catalog?id=203",
-                "allow": ['GET']}
+                "allow": ["GET"]}
         },
         "attributes": {
             "catalog.id": "203",
@@ -509,7 +509,7 @@ To get the products for a category, use the *f_catid* filter parameter:
     ```
 === "jQuery"
     ```javascript
-    var paramsObj = {
+    var args = {
         'filter': {
             'f_catid': '1'
         }
@@ -517,9 +517,9 @@ To get the products for a category, use the *f_catid* filter parameter:
     var params;
 
     if(options.meta.prefix) { // returned from OPTIONS call
-        params[options.meta.prefix] = paramsObj;
+        params[options.meta.prefix] = args;
     } else {
-        params = paramsObj;
+        params = args;
     }
 
     $.ajax({
@@ -540,7 +540,7 @@ By default, all the found products use "default" as the category list type. You 
     ```
 === "jQuery"
     ```javascript
-    var paramsObj = {
+    var args = {
         'filter': {
             'f_catid': '1',
             'f_listtype': 'promotion'
@@ -549,9 +549,9 @@ By default, all the found products use "default" as the category list type. You 
     var params;
 
     if(options.meta.prefix) { // returned from OPTIONS call
-        params[options.meta.prefix] = paramsObj;
+        params[options.meta.prefix] = args;
     } else {
-        params = paramsObj;
+        params = args;
     }
 
     $.ajax({
@@ -574,13 +574,13 @@ The product attributes for building the faceted search can be retrieved using th
     ```
 === "jQuery"
     ```javascript
-    var paramsObj = {'include': 'media,text'};
+    var args = {'include': 'media,text'};
     var params;
 
     if(options.meta.prefix) { // returned from OPTIONS call
-        params[options.meta.prefix] = paramsObj;
+        params[options.meta.prefix] = args;
     } else {
-        params = paramsObj;
+        params = args;
     }
 
     $.ajax({
@@ -604,7 +604,7 @@ This will return the first slice of attribute items as well as their related tex
         "links": {
             "self": {
                 "href": "http:\/\/localhost:8000\/jsonapi\/attribute?id=32",
-                "allow": ['GET']
+                "allow": ["GET"]
             }
         },
         "attributes": {
@@ -678,7 +678,7 @@ If the user selects one or more of the attributes, you can get the corresponding
     ```
 === "jQuery"
     ```javascript
-    var paramsObj = {
+    var args = {
         'filter': {
             'f_attrid': ['1','3']
         }
@@ -686,9 +686,9 @@ If the user selects one or more of the attributes, you can get the corresponding
     var params;
 
     if(options.meta.prefix) { // returned from OPTIONS call
-        params[options.meta.prefix] = paramsObj;
+        params[options.meta.prefix] = args;
     } else {
-        params = paramsObj;
+        params = args;
     }
 
     $.ajax({
@@ -709,7 +709,7 @@ Instead of *f_attrid* which combines all attributes by an **AND** condition, you
     ```
 === "jQuery"
     ```javascript
-    var paramsObj = {
+    var args = {
         'filter': {
             'f_optid': ['1','3']
         }
@@ -717,9 +717,9 @@ Instead of *f_attrid* which combines all attributes by an **AND** condition, you
     var params;
 
     if(options.meta.prefix) { // returned from OPTIONS call
-        params[options.meta.prefix] = paramsObj;
+        params[options.meta.prefix] = args;
     } else {
-        params = paramsObj;
+        params = args;
     }
 
     $.ajax({
@@ -740,7 +740,7 @@ Or you can use *f_oneid* with pairs of attribute types and list of attribute IDs
     ```
 === "jQuery"
     ```javascript
-    var paramsObj = {
+    var args = {
         'filter': {
             'f_oneid': {
                 'color': ['1'],
@@ -751,9 +751,9 @@ Or you can use *f_oneid* with pairs of attribute types and list of attribute IDs
     var params;
 
     if(options.meta.prefix) { // returned from OPTIONS call
-        params[options.meta.prefix] = paramsObj;
+        params[options.meta.prefix] = args;
     } else {
-        params = paramsObj;
+        params = args;
     }
 
     $.ajax({
@@ -776,13 +776,13 @@ To fetch the suppliers for building the supplier facet, you should use the "supp
     ```
 === "jQuery"
     ```javascript
-    var paramsObj = {'include': 'media,text'};
+    var args = {'include': 'media,text'};
     var params;
 
     if(options.meta.prefix) { // returned from OPTIONS call
-        params[options.meta.prefix] = paramsObj;
+        params[options.meta.prefix] = args;
     } else {
-        params = paramsObj;
+        params = args;
     }
 
     $.ajax({
@@ -806,7 +806,7 @@ This will return the first slice of supplier items as well as their associated t
         "links": {
             "self": {
                 "href": "http:\/\/localhost:8000\/jsonapi\/supplier?id=32",
-                "allow": ['GET']
+                "allow": ["GET"]
             }
         },
         "attributes": {
@@ -874,7 +874,7 @@ If the user selects a supplier, you can get the corresponding products by adding
     ```
 === "jQuery"
     ```javascript
-    var paramsObj = {
+    var args = {
         'filter': {
             'f_supid': '1'
         }
@@ -882,9 +882,9 @@ If the user selects a supplier, you can get the corresponding products by adding
     var params;
 
     if(options.meta.prefix) { // returned from OPTIONS call
-        params[options.meta.prefix] = paramsObj;
+        params[options.meta.prefix] = args;
     } else {
-        params = paramsObj;
+        params = args;
     }
 
     $.ajax({
@@ -911,13 +911,13 @@ You can get the attribute counts by using the **aggregate** key and the correspo
     ```
 === "jQuery"
     ```javascript
-    var paramsObj = {'aggregate': 'index.attribute.id'};
+    var args = {'aggregate': 'index.attribute.id'};
     var params;
 
     if(options.meta.prefix) { // returned from OPTIONS call
-        params[options.meta.prefix] = paramsObj;
+        params[options.meta.prefix] = args;
     } else {
-        params = paramsObj;
+        params = args;
     }
 
     $.ajax({
@@ -955,13 +955,13 @@ In the same way you can get the product counts for the categories by using the *
     ```
 === "jQuery"
     ```javascript
-    var paramsObj = {'aggregate': 'index.catalog.id'};
+    var args = {'aggregate': 'index.catalog.id'};
     var params;
 
     if(options.meta.prefix) { // returned from OPTIONS call
-        params[options.meta.prefix] = paramsObj;
+        params[options.meta.prefix] = args;
     } else {
-        params = paramsObj;
+        params = args;
     }
 
     $.ajax({
@@ -997,13 +997,13 @@ To get the product counts for the suppliers, use the **aggregate** key and the c
     ```
 === "jQuery"
     ```javascript
-    var paramsObj = {'aggregate': 'index.supplier.id'};
+    var args = {'aggregate': 'index.supplier.id'};
     var params;
 
     if(options.meta.prefix) { // returned from OPTIONS call
-        params[options.meta.prefix] = paramsObj;
+        params[options.meta.prefix] = args;
     } else {
-        params = paramsObj;
+        params = args;
     }
 
     $.ajax({
@@ -1039,7 +1039,7 @@ If you don't fetch the stock levels together with the products using *&include=s
     ```
 === "jQuery"
     ```javascript
-    var paramsObj = {
+    var args = {
         'filter': {
             's_prodcode': ['ABCD']
         }
@@ -1047,9 +1047,9 @@ If you don't fetch the stock levels together with the products using *&include=s
     var params;
 
     if(options.meta.prefix) { // returned from OPTIONS call
-        params[options.meta.prefix] = paramsObj;
+        params[options.meta.prefix] = args;
     } else {
-        params = paramsObj;
+        params = args;
     }
 
     $.ajax({
@@ -1072,7 +1072,7 @@ It returns the list of stock items for the given product codes:
         "links": {
             "self": {
                 "href": "http:\/\/localhost:8000\/jsonapi\/stock\/12",
-                "allow": ['GET']
+                "allow": ["GET"]
             }
         },
         "attributes": {
@@ -1095,7 +1095,7 @@ If the shop has different warehouses or local stores where customers can pick up
     ```
 === "jQuery"
     ```javascript
-    var paramsObj = {
+    var args = {
         'filter': {
             's_prodcode': ['ABCD'],
             's_stocktype': 'berlin'
@@ -1104,9 +1104,9 @@ If the shop has different warehouses or local stores where customers can pick up
     var params;
 
     if(options.meta.prefix) { // returned from OPTIONS call
-        params[options.meta.prefix] = paramsObj;
+        params[options.meta.prefix] = args;
     } else {
-        params = paramsObj;
+        params = args;
     }
 
     $.ajax({

--- a/src/frontend/jsonapi/catalog.md
+++ b/src/frontend/jsonapi/catalog.md
@@ -23,13 +23,13 @@ The response will contain the required endpoints you have to use:
 
 Have a look at [retrieving an OPTIONS request](index.md#retrieve-meta-data) for more details.
 
-For each endpoint, you can use an OPTIONS request to get the supported filter and sort keys:
+For each endpoint you can use an OPTIONS request to get the supported filter and sort keys:
 
 ```bash
 curl -X OPTIONS 'http://localhost:8000/jsonapi/product'
 ```
 
-It also returns the [prefix](index.md#nested-parameters) you have to use if the value is not `null` and the base URL for media files:
+It also returns the [prefix](index.md#nested-parameters) you have to use, if the value is not `null`, and the base URL for media files:
 
 ```json
 {
@@ -38,10 +38,10 @@ It also returns the [prefix](index.md#nested-parameters) you have to use if the 
     "content-baseurl": "http://localhost:8000/",
     "filter": {
         "f_search": {
-        "label": "Return products whose text matches the user input",
-        "type": "string",
-        "default": "",
-        "required": false
+            "label": "Return products whose text matches the user input",
+            "type": "string",
+            "default": "",
+            "required": false
         },
     },
     "sort": {
@@ -81,7 +81,7 @@ curl -X GET 'http://localhost:8000/jsonapi/product?include=attribute,media,price
         "links": {
             "self": {
                 "href": "http:\/\/localhost:8000\/jsonapi\/product\/13",
-                "allow": ["GET"]
+                "allow": ['GET']
             },
             "basket\/product": {
                 "href": "http:\/\/localhost:8000\/jsonapi\/basket\/default\/product",
@@ -257,7 +257,7 @@ curl -X GET 'http://localhost:8000/jsonapi/product?include=attribute,media,price
 
 # Sort product lists
 
-Additional to the generic filter possibilities, the product lists can be easily sorted by these keys:
+Additional to the generic filter possibilities, the product lists can be sorted easily by these keys:
 
 * "relevance" (asc) or "-relevance" (desc)
 * "name" (asc) or "-name" (desc)
@@ -270,15 +270,18 @@ Additional to the generic filter possibilities, the product lists can be easily 
     ```
 === "jQuery"
     ```javascript
-    var params = {'sort': '-ctime'};
+    var paramsObj = {'sort': '-ctime'};
+    var params;
 
     if(options.meta.prefix) { // returned from OPTIONS call
-        params[options.meta.prefix] = params;
+        params[options.meta.prefix] = paramsObj;
+    } else {
+        params = paramsObj;
     }
 
     $.ajax({
-        method: "GET",
-        dataType: "json",
+        method: 'GET',
+        dataType: 'json',
         url: options.meta.resources['product'], // returned from OPTIONS call
         data: params
     }).done( function( result ) {
@@ -286,7 +289,7 @@ Additional to the generic filter possibilities, the product lists can be easily 
     });
     ```
 
-Sorting by "relevance" is the default if no sort parameter is passed to the server. You can also sort by other product fields, e.g. by the start date of the products using *&sort=product.datestart*
+Sorting by "relevance" is the default sorting parameter if no other is passed to the server. You can also sort by other product fields, e.g. by the start date of the products using *&sort=product.datestart*
 
 # Search products by text
 
@@ -298,19 +301,22 @@ If you offer users a search field for products, you have to add the entered text
     ```
 === "jQuery"
     ```javascript
-    var params = {
+    var paramsObj = {
         'filter': {
             'f_search': 'demo'
         }
     };
+    var params;
 
     if(options.meta.prefix) { // returned from OPTIONS call
-        params[options.meta.prefix] = params;
+        params[options.meta.prefix] = paramsObj;
+    } else {
+        params = paramsObj;
     }
 
     $.ajax({
-        method: "GET",
-        dataType: "json",
+        method: 'GET',
+        dataType: 'json',
         url: options.meta.resources['product'], // returned from OPTIONS call
         data: params
     }).done( function( result ) {
@@ -320,7 +326,7 @@ If you offer users a search field for products, you have to add the entered text
 
 # Filter products by price
 
-To enable users to filter products by price, you need to use the *index.price:value* filter and it requires the three letter currency code as parameter in round brackets and quotation marks ("). To return only products with a price of less than 99.50 Euro, you need:
+To enable users to filter products by price, you need to use the *index.price:value* filter as well as the three letter currency code as parameter in round brackets and quotation marks ("). To return only products with a price of less than e.g. 99.50 Euro you need:
 
 === "CURL"
     ```bash
@@ -328,19 +334,22 @@ To enable users to filter products by price, you need to use the *index.price:va
     ```
 === "jQuery"
     ```javascript
-    var params = {
+    var paramsObj = {
         'filter': {
             '<': {'index.price:value("EUR")': 99.50}
         }
     };
+    var params;
 
     if(options.meta.prefix) { // returned from OPTIONS call
-        params[options.meta.prefix] = params;
+        params[options.meta.prefix] = paramsObj;
+    } else {
+        params = paramsObj;
     }
 
     $.ajax({
-        method: "GET",
-        dataType: "json",
+        method: 'GET',
+        dataType: 'json',
         url: options.meta.resources['product'], // returned from OPTIONS call
         data: params
     }).done( function( result ) {
@@ -358,7 +367,7 @@ Usually, you want to filter for a price range, so you need to pass an upper and 
     ```
 === "jQuery"
     ```javascript
-    var params = {
+    var paramsObj = {
         'filter': {
             '&&': [
                 {'>': {'index.price:value("EUR")': 100}},
@@ -366,14 +375,17 @@ Usually, you want to filter for a price range, so you need to pass an upper and 
             ]
         }
     };
+    var params;
 
     if(options.meta.prefix) { // returned from OPTIONS call
-        params[options.meta.prefix] = params;
+        params[options.meta.prefix] = paramsObj;
+    } else {
+        params = paramsObj;
     }
 
     $.ajax({
-        method: "GET",
-        dataType: "json",
+        method: 'GET',
+        dataType: 'json',
         url: options.meta.resources['product'], // returned from OPTIONS call
         data: params
     }).done( function( result ) {
@@ -391,15 +403,18 @@ To display the category tree, you have to use the "catalog" resource returned by
     ```
 === "jQuery"
     ```javascript
-    var params = {"include": 'catalog,media,text'};
+    var paramsObj = {'include': 'catalog,media,text'};
+    var params;
 
     if(options.meta.prefix) { // returned from OPTIONS call
-        params[options.meta.prefix] = params;
+        params[options.meta.prefix] = paramsObj;
+    } else {
+        params = paramsObj;
     }
 
     $.ajax({
-        method: "GET",
-        dataType: "json",
+        method: 'GET',
+        dataType: 'json',
         url: options.meta.resources['catalog'], // returned from OPTIONS call
         data: params
     }).done( function( result ) {
@@ -407,7 +422,7 @@ To display the category tree, you have to use the "catalog" resource returned by
     });
     ```
 
-This will return the root catalog node and its direct children as well as the texts and images:
+This will return the root catalog node and its direct children as well as their related texts and images:
 
 ```json
 {
@@ -418,11 +433,11 @@ This will return the root catalog node and its direct children as well as the te
         "links": {
             "self": {
                 "href": "http:\/\/localhost:8000\/jsonapi\/catalog?id=201",
-                "allow": ["GET"]
+                "allow": ['GET']
             },
             "product": {"
                 href": "http:\/\/localhost:8000\/jsonapi\/product?filter%5Bf_catid%5D=201",
-                "allow": ["GET"]
+                "allow": ['GET']
             }
         },
         "attributes": {
@@ -448,7 +463,7 @@ This will return the root catalog node and its direct children as well as the te
         "links": {
             "self": {
                 "href": "http:\/\/localhost:8000\/jsonapi\/catalog?id=203",
-                "allow": ["GET"]}
+                "allow": ['GET']}
         },
         "attributes": {
             "catalog.id": "203",
@@ -494,19 +509,22 @@ To get the products for a category, use the *f_catid* filter parameter:
     ```
 === "jQuery"
     ```javascript
-    var params = {
+    var paramsObj = {
         'filter': {
             'f_catid': '1'
         }
     };
+    var params;
 
     if(options.meta.prefix) { // returned from OPTIONS call
-        params[options.meta.prefix] = params;
+        params[options.meta.prefix] = paramsObj;
+    } else {
+        params = paramsObj;
     }
 
     $.ajax({
-        method: "GET",
-        dataType: "json",
+        method: 'GET',
+        dataType: 'json',
         url: options.meta.resources['product'], // returned from OPTIONS call
         data: params
     }).done( function( result ) {
@@ -514,7 +532,7 @@ To get the products for a category, use the *f_catid* filter parameter:
     });
     ```
 
-By default, the found products all use "default" as category list type. You can change the list type searched for by adding the *f_listtype* parameter to e.g. **promotion** to get promotional products:
+By default, all the found products use "default" as the category list type. You can change the list type searched for by adding the *f_listtype* parameter to e.g. **promotion** to get promotional products:
 
 === "CURL"
     ```bash
@@ -522,20 +540,23 @@ By default, the found products all use "default" as category list type. You can 
     ```
 === "jQuery"
     ```javascript
-    var params = {
+    var paramsObj = {
         'filter': {
             'f_catid': '1',
             'f_listtype': 'promotion'
         }
     };
+    var params;
 
     if(options.meta.prefix) { // returned from OPTIONS call
-        params[options.meta.prefix] = params;
+        params[options.meta.prefix] = paramsObj;
+    } else {
+        params = paramsObj;
     }
 
     $.ajax({
-        method: "GET",
-        dataType: "json",
+        method: 'GET',
+        dataType: 'json',
         url: options.meta.resources['product'], // returned from OPTIONS call
         data: params
     }).done( function( result ) {
@@ -553,15 +574,18 @@ The product attributes for building the faceted search can be retrieved using th
     ```
 === "jQuery"
     ```javascript
-    var params = {'include': 'media,text'};
+    var paramsObj = {'include': 'media,text'};
+    var params;
 
     if(options.meta.prefix) { // returned from OPTIONS call
-        params[options.meta.prefix] = params;
+        params[options.meta.prefix] = paramsObj;
+    } else {
+        params = paramsObj;
     }
 
     $.ajax({
-        method: "GET",
-        dataType: "json",
+        method: 'GET',
+        dataType: 'json',
         url: options.meta.resources['attribute'], // returned from OPTIONS call
         data: params
     }).done( function( result ) {
@@ -569,7 +593,7 @@ The product attributes for building the faceted search can be retrieved using th
     });
     ```
 
-This will return the first slice of attribute items as well as the texts and images:
+This will return the first slice of attribute items as well as their related texts and images:
 
 ```json
 {
@@ -580,7 +604,7 @@ This will return the first slice of attribute items as well as the texts and ima
         "links": {
             "self": {
                 "href": "http:\/\/localhost:8000\/jsonapi\/attribute?id=32",
-                "allow": ["GET"]
+                "allow": ['GET']
             }
         },
         "attributes": {
@@ -654,19 +678,22 @@ If the user selects one or more of the attributes, you can get the corresponding
     ```
 === "jQuery"
     ```javascript
-    var params = {
+    var paramsObj = {
         'filter': {
             'f_attrid': ['1','3']
         }
     };
+    var params;
 
     if(options.meta.prefix) { // returned from OPTIONS call
-        params[options.meta.prefix] = params;
+        params[options.meta.prefix] = paramsObj;
+    } else {
+        params = paramsObj;
     }
 
     $.ajax({
-        method: "GET",
-        dataType: "json",
+        method: 'GET',
+        dataType: 'json',
         url: options.meta.resources['product'], // returned from OPTIONS call
         data: params
     }).done( function( result ) {
@@ -682,19 +709,22 @@ Instead of *f_attrid* which combines all attributes by an **AND** condition, you
     ```
 === "jQuery"
     ```javascript
-    var params = {
+    var paramsObj = {
         'filter': {
             'f_optid': ['1','3']
         }
     };
+    var params;
 
     if(options.meta.prefix) { // returned from OPTIONS call
-        params[options.meta.prefix] = params;
+        params[options.meta.prefix] = paramsObj;
+    } else {
+        params = paramsObj;
     }
 
     $.ajax({
-        method: "GET",
-        dataType: "json",
+        method: 'GET',
+        dataType: 'json',
         url: options.meta.resources['product'], // returned from OPTIONS call
         data: params
     }).done( function( result ) {
@@ -702,7 +732,7 @@ Instead of *f_attrid* which combines all attributes by an **AND** condition, you
     });
     ```
 
-Or you can use *f_oneid* with pairs of attribute types and list of attribute IDs to filter for product that contains **at least one** of the attributes per type:
+Or you can use *f_oneid* with pairs of attribute types and list of attribute IDs to filter for products that contain **at least one** of the attributes per type:
 
 === "CURL"
     ```bash
@@ -710,7 +740,7 @@ Or you can use *f_oneid* with pairs of attribute types and list of attribute IDs
     ```
 === "jQuery"
     ```javascript
-    var params = {
+    var paramsObj = {
         'filter': {
             'f_oneid': {
                 'color': ['1'],
@@ -718,14 +748,17 @@ Or you can use *f_oneid* with pairs of attribute types and list of attribute IDs
             }
         }
     };
+    var params;
 
     if(options.meta.prefix) { // returned from OPTIONS call
-        params[options.meta.prefix] = params;
+        params[options.meta.prefix] = paramsObj;
+    } else {
+        params = paramsObj;
     }
 
     $.ajax({
-        method: "GET",
-        dataType: "json",
+        method: 'GET',
+        dataType: 'json',
         url: options.meta.resources['product'], // returned from OPTIONS call
         data: params
     }).done( function( result ) {
@@ -743,15 +776,18 @@ To fetch the suppliers for building the supplier facet, you should use the "supp
     ```
 === "jQuery"
     ```javascript
-    var params = {'include': 'media,text'};
+    var paramsObj = {'include': 'media,text'};
+    var params;
 
     if(options.meta.prefix) { // returned from OPTIONS call
-        params[options.meta.prefix] = params;
+        params[options.meta.prefix] = paramsObj;
+    } else {
+        params = paramsObj;
     }
 
     $.ajax({
-        method: "GET",
-        dataType: "json",
+        method: 'GET',
+        dataType: 'json',
         url: options.meta.resources['supplier'], // returned from OPTIONS call
         data: params
     }).done( function( result ) {
@@ -759,7 +795,7 @@ To fetch the suppliers for building the supplier facet, you should use the "supp
     });
     ```
 
-This will return the first slice of supplier items as well as the texts and images:
+This will return the first slice of supplier items as well as their associated texts and images:
 
 ```json
 {
@@ -770,7 +806,7 @@ This will return the first slice of supplier items as well as the texts and imag
         "links": {
             "self": {
                 "href": "http:\/\/localhost:8000\/jsonapi\/supplier?id=32",
-                "allow": ["GET"]
+                "allow": ['GET']
             }
         },
         "attributes": {
@@ -838,19 +874,22 @@ If the user selects a supplier, you can get the corresponding products by adding
     ```
 === "jQuery"
     ```javascript
-    var params = {
+    var paramsObj = {
         'filter': {
             'f_supid': '1'
         }
     };
+    var params;
 
     if(options.meta.prefix) { // returned from OPTIONS call
-        params[options.meta.prefix] = params;
+        params[options.meta.prefix] = paramsObj;
+    } else {
+        params = paramsObj;
     }
 
     $.ajax({
-        method: "GET",
-        dataType: "json",
+        method: 'GET',
+        dataType: 'json',
         url: options.meta.resources['product'], // returned from OPTIONS call
         data: params
     }).done( function( result ) {
@@ -872,15 +911,18 @@ You can get the attribute counts by using the **aggregate** key and the correspo
     ```
 === "jQuery"
     ```javascript
-    var params = {'aggregate': 'index.attribute.id'};
+    var paramsObj = {'aggregate': 'index.attribute.id'};
+    var params;
 
     if(options.meta.prefix) { // returned from OPTIONS call
-        params[options.meta.prefix] = params;
+        params[options.meta.prefix] = paramsObj;
+    } else {
+        params = paramsObj;
     }
 
     $.ajax({
-        method: "GET",
-        dataType: "json",
+        method: 'GET',
+        dataType: 'json',
         url: options.meta.resources['product'], // returned from OPTIONS call
         data: params
     }).done( function( result ) {
@@ -888,7 +930,7 @@ You can get the attribute counts by using the **aggregate** key and the correspo
     });
     ```
 
-This will return a list of "id" and "attributes" pairs where the value of "id" is the attribute ID and "attributes" is the number of products that contains that attribute:
+This will return a list of "id" and "attributes" pairs where the value of "id" is the attribute ID and "attributes" is the number of products that contain that attribute:
 
 ```javascript
 {
@@ -897,8 +939,8 @@ This will return a list of "id" and "attributes" pairs where the value of "id" i
     },
     "data": [
         {"id":25, "type":"index.attribute.id", "attributes":"2"},
-        {"id":26,"type":"index.attribute.id","attributes":"2"},
-        {"id":29,"type":"index.attribute.id","attributes":"1"}
+        {"id":26, "type":"index.attribute.id","attributes":"2"},
+        {"id":29, "type":"index.attribute.id","attributes":"1"}
     ]
 }
 ```
@@ -913,15 +955,18 @@ In the same way you can get the product counts for the categories by using the *
     ```
 === "jQuery"
     ```javascript
-    var params = {'aggregate': 'index.catalog.id'};
+    var paramsObj = {'aggregate': 'index.catalog.id'};
+    var params;
 
     if(options.meta.prefix) { // returned from OPTIONS call
-        params[options.meta.prefix] = params;
+        params[options.meta.prefix] = paramsObj;
+    } else {
+        params = paramsObj;
     }
 
     $.ajax({
-        method: "GET",
-        dataType: "json",
+        method: 'GET',
+        dataType: 'json',
         url: options.meta.resources['product'], // returned from OPTIONS call
         data: params
     }).done( function( result ) {
@@ -952,15 +997,18 @@ To get the product counts for the suppliers, use the **aggregate** key and the c
     ```
 === "jQuery"
     ```javascript
-    var params = {'aggregate': 'index.supplier.id'};
+    var paramsObj = {'aggregate': 'index.supplier.id'};
+    var params;
 
     if(options.meta.prefix) { // returned from OPTIONS call
-        params[options.meta.prefix] = params;
+        params[options.meta.prefix] = paramsObj;
+    } else {
+        params = paramsObj;
     }
 
     $.ajax({
-        method: "GET",
-        dataType: "json",
+        method: 'GET',
+        dataType: 'json',
         url: options.meta.resources['product'], // returned from OPTIONS call
         data: params
     }).done( function( result ) {
@@ -991,19 +1039,22 @@ If you don't fetch the stock levels together with the products using *&include=s
     ```
 === "jQuery"
     ```javascript
-    var params = {
+    var paramsObj = {
         'filter': {
             's_prodcode': ['ABCD']
         }
     };
+    var params;
 
     if(options.meta.prefix) { // returned from OPTIONS call
-        params[options.meta.prefix] = params;
+        params[options.meta.prefix] = paramsObj;
+    } else {
+        params = paramsObj;
     }
 
     $.ajax({
-        method: "GET",
-        dataType: "json",
+        method: 'GET',
+        dataType: 'json',
         url: options.meta.resources['stock'], // returned from OPTIONS call
         data: params
     }).done( function( result ) {
@@ -1021,7 +1072,7 @@ It returns the list of stock items for the given product codes:
         "links": {
             "self": {
                 "href": "http:\/\/localhost:8000\/jsonapi\/stock\/12",
-                "allow": ["GET"]
+                "allow": ['GET']
             }
         },
         "attributes": {
@@ -1044,20 +1095,23 @@ If the shop has different warehouses or local stores where customers can pick up
     ```
 === "jQuery"
     ```javascript
-    var params = {
+    var paramsObj = {
         'filter': {
             's_prodcode': ['ABCD'],
             's_stocktype': 'berlin'
         }
     };
+    var params;
 
     if(options.meta.prefix) { // returned from OPTIONS call
-        params[options.meta.prefix] = params;
+        params[options.meta.prefix] = paramsObj;
+    } else {
+        params = paramsObj;
     }
 
     $.ajax({
-        method: "GET",
-        dataType: "json",
+        method: 'GET',
+        dataType: 'json',
         url: options.meta.resources['stock'], // returned from OPTIONS call
         data: params
     }).done( function( result ) {

--- a/src/frontend/jsonapi/catalog.md
+++ b/src/frontend/jsonapi/catalog.md
@@ -253,11 +253,11 @@ curl -X GET 'http://localhost:8000/jsonapi/product?include=attribute,media,price
 ```
 
 !!! note
-    Returning categories, suppliers and stock items in the product response is available since 2020.07
+    Returning categories, suppliers and stock items in the product response is available since 2020.07.
 
 # Sort product lists
 
-Additional to the generic filter possibilities, the product lists can be sorted easily by these keys:
+In addition to the generic filter possibilities, the product lists can be sorted easily by these keys:
 
 * "relevance" (asc) or "-relevance" (desc)
 * "name" (asc) or "-name" (desc)
@@ -326,7 +326,7 @@ If you offer users a search field for products, you have to add the entered text
 
 # Filter products by price
 
-To enable users to filter products by price, you need to use the *index.price:value* filter as well as the three letter currency code as parameter in round brackets and quotation marks ("). To return only products with a price of less than e.g. 99.50 Euro you need:
+To enable users to filter products by price, you need to use the *index.price:value* filter as well as the three letter currency code as parameter in round brackets and quotation marks ("). To return only products with a price of less than e.g. 99.50 Euro, you need:
 
 === "CURL"
     ```bash
@@ -497,7 +497,7 @@ This will return the root catalog node and its direct children as well as their 
 ]}
 ```
 
-You can repeat this with the catalog children returned in the "included" section to get their children. In **links[self]** of the children, the right URL for retrieving them is available.
+If you wish to display the children's children of a specific category, use the URL that is provided by the **links[self]** key in the "included" section.
 
 # Get products by category
 
@@ -701,7 +701,7 @@ If the user selects one or more of the attributes, you can get the corresponding
     });
     ```
 
-Instead of *f_attrid* which combines all attributes by an **AND** condition, you can also use *f_optid* which uses an **OR** condition:
+Instead of *f_attrid* which combines all attributes with an **AND** condition, you can also use *f_optid* which uses an **OR** condition:
 
 === "CURL"
     ```bash
@@ -768,7 +768,7 @@ Or you can use *f_oneid* with pairs of attribute types and list of attribute IDs
 
 # Suppliers for faceted search
 
-To fetch the suppliers for building the supplier facet, you should use the "supplier" resource returned by the OPTIONS method:
+To fetch the suppliers for building the supplier facet, use the "supplier" resource returned by the OPTIONS method:
 
 === "CURL"
     ```bash

--- a/src/frontend/jsonapi/customer-addresses.md
+++ b/src/frontend/jsonapi/customer-addresses.md
@@ -1,7 +1,7 @@
 Aimeos allows several delivery addresses for each customer but customers must be authenticated before they can add, delete, retrieve and update their addresses.
 
 !!! tip
-    How to authenticate the user depends on the used PHP framework. Please have a look into the documentation of your used framework, e.g. at Laravel [Passport](https://laravel.com/docs/master/passport)/[Sanctum](https://laravel.com/docs/master/sanctum) or Symfony [Guard](https://symfony.com/doc/current/security/guard_authentication.html).
+    The way how a user is authenticated depends very much on the PHP framework you use. Please have a look into the documentation of your framework of choice, e.g. at Laravel [Passport](https://laravel.com/docs/master/passport)/[Sanctum](https://laravel.com/docs/master/sanctum) or Symfony [Guard](https://symfony.com/doc/current/security/guard_authentication.html).
 
 The customer response returnes the URLs for managing addresses:
 
@@ -46,7 +46,7 @@ To retrieve the delivery addresses of the customer, you have to send a GET reque
     });
     ```
 
-If there's at least one delivery address available, the response looks like:
+If there's at least one delivery address available, the response looks like this:
 
 ```json
 {
@@ -135,7 +135,7 @@ There are some address attributes that are suggested when adding an address:
 * customer.address.city (town or city name)
 * customer.address.languageid (language the customer prefers)
 
-The request for creating a new delivery address could look like:
+The request for creating a new delivery address could look like this:
 
 === "CURL"
     ```bash
@@ -214,7 +214,7 @@ The request for creating a new delivery address could look like:
 
 # Modify address
 
-In the same way you can add address, you can change one or more address fields of the authenticated customer using a PATCH request. The URL for updating an address is returned by the GET response containing the customer delivery addresses. You can add all address fields or only the modified ones in the PATCH request:
+In the same way you can add an address, you can change one or more address fields of the authenticated customer using a PATCH request. The URL for updating an address is returned by the GET response containing the customer delivery addresses. You can add all address fields or only the modified ones in the PATCH request:
 
 === "CURL"
     ```bash
@@ -257,14 +257,13 @@ In the same way you can add address, you can change one or more address fields o
 
 # Delete addresses
 
-You can also remove delivery addresses from the customer account by using a DELETE request to the URL of the customer address. In our first response above, the URL is:
+You can also remove delivery addresses from the customer account by using a DELETE request to the URL of the customer's address. In our first response above, the URL is:
 
 ```
 http://localhost:8000/jsonapi/customer?id=2&related=address&relatedid=2
 ```
 
-Use code like that to contruct the DELETE request:
-
+Use code like this one to construct a DELETE request:
 
 === "CURL"
     ```bash
@@ -290,4 +289,4 @@ Use code like that to contruct the DELETE request:
     });
     ```
 
-This request will remove the address entry from the user account and an additional GET request to retrieve the addresses won't contain the address any more.
+This request will remove the address entry with id 2 from the user account. Any subsequent GET requests to retrieve the customer's addresses won't contain the address with the id 2 anymore.

--- a/src/frontend/jsonapi/customer-properties.md
+++ b/src/frontend/jsonapi/customer-properties.md
@@ -1,7 +1,7 @@
 You can store arbitrary key/language/value pairs in each customer account for different purposes. The JSON REST API allows you to manage them for the authenticated user.
 
 !!! tip
-    How to authenticate the user depends on the used PHP framework. Please have a look into the documentation of your used framework, e.g. at Laravel [Passport](https://laravel.com/docs/master/passport)/[Sanctum](https://laravel.com/docs/master/sanctum) or Symfony [Guard](https://symfony.com/doc/current/security/guard_authentication.html)).
+    The way how a user is authenticated depends very much on the PHP framework you use. Please have a look into the documentation of your framework of choice, e.g. at Laravel [Passport](https://laravel.com/docs/master/passport)/[Sanctum](https://laravel.com/docs/master/sanctum) or Symfony [Guard](https://symfony.com/doc/current/security/guard_authentication.html)).
 
 The customer response returnes the URLs for managing properties:
 
@@ -28,7 +28,7 @@ The customer response returnes the URLs for managing properties:
 
 # Fetch properties
 
-Retrieving the properties of the customer requires a GET request to the *customer/property* endpoint returned by the GET request for the [customer](customer.md), e.g.:
+Retrieving the properties of a customer requires a GET request to the *customer/property* endpoint returned by the GET request for the [customer](customer.md), e.g.:
 
 === "CURL"
     ```bash
@@ -83,7 +83,7 @@ When at least one property is available, the response will be similar to this on
 
 # Add properties
 
-To add one or more properties to the authenticated customer, use a POST request including the property data. The URL for that request is returned by the GET request to the [customer endpoint](customer.md) and contains a *customer/property* entry in the *links* section:
+To add one or more properties to an authenticated customer, use a POST request including the property data. The URL for that request is returned by the GET request to the [customer endpoint](customer.md) and contains a *customer/property* entry in the *links* section:
 
 ```json
 {
@@ -100,7 +100,7 @@ To add one or more properties to the authenticated customer, use a POST request 
         "self": "http://localhost:8080/jsonapi/customer",
         "customer/property": {
             "href": "http://localhost:8080/jsonapi/customer?related=property",
-                "allow": ["GET","POST"]
+            "allow": ["GET","POST"]
         }
     }
 }
@@ -157,7 +157,7 @@ The request for creating a new property looks similar to this one:
 
 # Modify property
 
-Changing one property of the authenticated customer is possible by executing a PATCH request. The URL for updating the property is returned in the response of the GET request which fetches all properties. You can add all property fields or only the modified ones in the PATCH request:
+Changing one property of an authenticated customer is possible by executing a PATCH request. The URL for updating the property is returned in the response of the GET request which fetches all properties. You can add all property fields or only the modified ones in the PATCH request:
 
 === "CURL"
     ```bash
@@ -204,8 +204,7 @@ Removing properties from the user account is also possible by executing a DELETE
 http://localhost:8000/jsonapi/customer?id=2&related=property&relatedid=1
 ```
 
-The DELETE request can be constructed that way:
-
+The DELETE request can be constructed like this:
 
 === "CURL"
     ```bash

--- a/src/frontend/jsonapi/customer-relations.md
+++ b/src/frontend/jsonapi/customer-relations.md
@@ -1,9 +1,9 @@
-Each customer account can store relations to other domains for different purposes, e.g. for favorite or watched products . The JSON REST API allows you to manage them for the authenticated user.
+Each customer account can store relations to other domains for different purposes, e.g. for favorite or watched products. The JSON REST API allows you to manage them for an authenticated user.
 
 !!! tip
-    How to authenticate the user depends on the used PHP framework. Please have a look into the documentation of your used framework, e.g. at Laravel [Passport](https://laravel.com/docs/master/passport)/[Sanctum](https://laravel.com/docs/master/sanctum) or Symfony [Guard](https://symfony.com/doc/current/security/guard_authentication.html).
+    The way how a user is authenticated depends very much on the PHP framework you use. Please have a look into the documentation of your framework of choice, e.g. at Laravel [Passport](https://laravel.com/docs/master/passport)/[Sanctum](https://laravel.com/docs/master/sanctum) or Symfony [Guard](https://symfony.com/doc/current/security/guard_authentication.html).
 
-The customer response can return more than the URLs for managing relations, it can also include the related items itself. Add the *include* parameter with the domain of the items you want to fetch, e.g. *&include=product* to get:
+In addition to the URLs for managing relations, the customer response can also include the related items themselves. Add the *include* parameter with the domain of the items you want to fetch, e.g. *&include=product* to get:
 
 ```json
 {
@@ -92,25 +92,29 @@ To get the relations only, use a GET request to the *customer/relationships* end
 === "jQuery"
     ```javascript
     var url = response['links']['customer/relationships']['href']; // from customer response
-    var $params = {include: "product"};
+    var args = {include: "product"};
+    var params;
 
     if(options.meta.prefix) { // returned from OPTIONS call
-        params[options.meta.prefix] = params;
+        params[options.meta.prefix] = args;
+    } else {
+        params = args
     }
 
     $.ajax({
         url: url,
         method: "GET",
-        dataType: "json"
+        dataType: "json",
+        data: params
     }).done( function( result ) {
         console.log( result.data );
     });
     ```
 
 !!! note
-    Don't forget to add the *include* parameter to specify which domain items you want to retrieve. If you forget that parameter, no relations are returned even if there are items referenced by the customer account!
+    Don't forget to add the *include* parameter to specify which domain items you want to retrieve. If you forget that parameter, no relations will be returned even if there are items referenced by the customer account!
 
-The response will look like this one if at least one relationship is available:
+The response will look similar to this one if at least one relationship is available:
 
 ```json
 {
@@ -153,7 +157,7 @@ The response will look like this one if at least one relationship is available:
 
 # Add relations
 
-To add one or more relations to the authenticated customer, use a POST request including the relationship data, i.e. the data for the list item. The URL for that request is returned by the GET request to the [customer endpoint](customer.md) and contains a *customer/relationships* entry in the *links* section:
+To add one or more relations to an authenticated customer, use a POST request including the relationship data, i.e. the data for the list item. The URL for that request is returned by the GET request to the [customer endpoint](customer.md) and contains a *customer/relationships* entry in the *links* section:
 
 ```json
 {
@@ -260,7 +264,7 @@ The request for creating a new relation looks similar to this one:
     ```
 
 !!! note
-    If you want to get the created relationship back, add the *include* parameter with the domain you have added the item for.
+    If you want to get back the created relationship, add the *include* parameter with the domain to which you have just added the item.
 
 ## Favorite products
 
@@ -465,7 +469,6 @@ http://localhost:8000/jsonapi/customer?id=2&related=relationships&relatedid=1
 
 A DELETE request is performed by:
 
-
 === "CURL"
     ```bash
     curl -b cookies.txt -c cookies.txt \
@@ -490,4 +493,4 @@ A DELETE request is performed by:
     });
     ```
 
-Then, the relation entry identified by its ID is removed from the customer account.
+Then, the relation entry identified by its ID is removed from the customer's account.

--- a/src/frontend/jsonapi/customer-relations.md
+++ b/src/frontend/jsonapi/customer-relations.md
@@ -93,7 +93,7 @@ To get the relations only, use a GET request to the *customer/relationships* end
     ```javascript
     var url = response['links']['customer/relationships']['href']; // from customer response
     var args = {include: "product"};
-    var params;
+    var params = {};
 
     if(options.meta.prefix) { // returned from OPTIONS call
         params[options.meta.prefix] = args;

--- a/src/frontend/jsonapi/customer-reviews.md
+++ b/src/frontend/jsonapi/customer-reviews.md
@@ -1,7 +1,7 @@
 Customers can view, add and update their own reviews using the JSON REST API but they need to authenticate themselves first.
 
 !!! tip
-    How to authenticate the user depends on the used PHP framework. Please have a look into the documentation of your used framework, e.g. at Laravel [Passport](https://laravel.com/docs/master/passport)/[Sanctum](https://laravel.com/docs/master/sanctum) or Symfony [Guard](https://symfony.com/doc/current/security/guard_authentication.html).
+    The way how a user is authenticated depends very much on the PHP framework you use. Please have a look into the documentation of your framework of choice, e.g. at Laravel [Passport](https://laravel.com/docs/master/passport)/[Sanctum](https://laravel.com/docs/master/sanctum) or Symfony [Guard](https://symfony.com/doc/current/security/guard_authentication.html).
 
 The customer response returnes the URLs for managing reviews:
 
@@ -88,7 +88,7 @@ When at least one review is available, the response will be similar to this one:
 
 # Add reviews
 
-To add one or more reviews to the authenticated customer, use a POST request including the review data. The URL to add reviews is returned by the GET request to the [customer endpoint](customer.md), which contains a *customer/review* entry in the *links* section.
+To add one or more reviews to the authenticated customer, use a POST request including the review data. The URL to add reviews is returned by the GET request to the [customer endpoint](customer.md) which contains a *customer/review* entry in the *links* section.
 
 The available fields for reviews are:
 
@@ -164,7 +164,7 @@ Changing one review of the authenticated customer is possible by performing a PA
 === "CURL"
     ```bash
     curl -b cookies.txt -c cookies.txt \
-    -X PATCH 'http://localhost:8000/jsonapi/customer?related=review&relatedid=8&_token=sTVVJGBtJyarXfgrYOxL5hpGADLbYOMb1azBn79V' \
+    -X PATCH 'http://localhost:8000/jsonapi/customer?related=review&relatedid=8&_token=...' \
     -H 'Content-Type: application/json' \
     -d '{"data": {
         "attributes": {
@@ -208,13 +208,12 @@ Removing reviews from the user account is also possible by executing a DELETE re
 http://localhost:8000/jsonapi/customer?id=2&related=review&relatedid=1
 ```
 
-You can build a DELETE request using:
-
+You can build a DELETE request like this:
 
 === "CURL"
     ```bash
     curl -b cookies.txt -c cookies.txt \
-    -X DELETE 'http://localhost:8000/jsonapi/customer?related=review&relatedid=8&_token=sTVVJGBtJyarXfgrYOxL5hpGADLbYOMb1azBn79V'
+    -X DELETE 'http://localhost:8000/jsonapi/customer?related=review&relatedid=8&_token=...'
     ```
 === "jQuery"
     ```javascript
@@ -235,4 +234,4 @@ You can build a DELETE request using:
     });
     ```
 
-Then, the review identified by its ID is removed from the customer account.
+Then, the review identified by its ID is removed from the customer's account.

--- a/src/frontend/jsonapi/customer.md
+++ b/src/frontend/jsonapi/customer.md
@@ -21,7 +21,6 @@ curl -b cookies.txt -c cookies.txt \
 }
 ```
 
-
 The "csrf" section in "meta" is important to modify the customer data. Each response will contain such a "csrf" section if the host application supports tokens against cross-site request forgery attacks. If available, you have to send them with every DELETE, PATCH and POST request.
 
 !!! warning

--- a/src/frontend/jsonapi/customer.md
+++ b/src/frontend/jsonapi/customer.md
@@ -1,4 +1,4 @@
-To create a customer or modify his data, you need the customer resource endpoint from the OPTIONS request. Depending on the used routes it might be something like:
+To create a customer or modify her/his data, you need the customer resource endpoint from the OPTIONS request. Depending on the used routes, it might be something like this:
 
 ```bash
 curl -b cookies.txt -c cookies.txt \
@@ -25,7 +25,7 @@ curl -b cookies.txt -c cookies.txt \
 The "csrf" section in "meta" is important to modify the customer data. Each response will contain such a "csrf" section if the host application supports tokens against cross-site request forgery attacks. If available, you have to send them with every DELETE, PATCH and POST request.
 
 !!! warning
-    Don't take the resource URLs in the OPTIONS response as granted! They will change depending on the routes and the application. Thus, your client needs the OPTIONS URL of the JSON REST API as configuration parameter. It's response will define the next possibilities.
+    Don't take the resource URLs in the OPTIONS response as granted! They will change depending on the routes and the application. Thus, your client needs the OPTIONS URL of the JSON REST API as configuration parameter. Its response will define the next possibilities.
 
 # Fetch customer data
 
@@ -47,7 +47,7 @@ To get the customer entry, you have to send a GET request to the customer endpoi
     });
     ```
 
-If the customer didn't authenticate himself yet, an empty customer item is returned:
+If the customer didn't authenticate herself/himself yet, an empty customer item is returned:
 
 ```json
 {
@@ -118,9 +118,9 @@ If the customer didn't authenticate himself yet, an empty customer item is retur
 ```
 
 !!! tip
-    How to authenticate the user depends on the used PHP framework. Please have a look into the documentation of your used framework, e.g. at Laravel [Passport](https://laravel.com/docs/master/passport)/[Sanctum](https://laravel.com/docs/master/sanctum) or Symfony [Guard](https://symfony.com/doc/current/security/guard_authentication.html).
+    The way how a user is authenticated depends very much on the PHP framework you use. Please have a look at the documentation of the respective framework of your choice, e.g. at Laravel [Passport](https://laravel.com/docs/master/passport)/[Sanctum](https://laravel.com/docs/master/sanctum) or Symfony [Guard](https://symfony.com/doc/current/security/guard_authentication.html).
 
-For an authenticated user, the response will contain the account data and the groups assigned to the user:
+The response of an authenticated user contains the account data and the groups assigned to the user:
 
 ```json
 {
@@ -224,7 +224,7 @@ For an authenticated user, the response will contain the account data and the gr
 
 If you don't need all data, you can [limit the fields](basics.md#return-specific-fields-only) returned by adding *&fields[customer]=...* to the URL, e.g. "&fields[customer]=customer.code,customer.email".
 
-To fetch addresses or other [related data](basics.md#include-related-resources) too, you can add *&include=...* to the URL so the related data is returned in the response too. Available related resources are:
+To fetch addresses or other [related data](basics.md#include-related-resources), too, you can add *&include=...* to the URL, so the related data is returned in the response as well. Available related resources are:
 
 * *customer/address* : List of delivery addresses
 * *customer/property* : List of properties stored for the user
@@ -322,7 +322,7 @@ If the user isn't logged in, it's possible to create a new customer by sending t
     });
     ```
 
-You can't set the "customer.status" and "customer.groups" properties for an account using the JSON API. If you do so, they will be ignored because obviously, this would enable attackers to re-enable their disabled account or gain additional privileges.
+You can't set the "customer.status" and "customer.groups" properties for an account using the JSON API. If you do so, they will be ignored because, obviously, this would enable attackers to re-enable their disabled account or gain additional privileges.
 
 In case the new account has been successfully created, the response will be similar to this one:
 
@@ -548,16 +548,16 @@ The response will include the basic customer data including groups like in this 
 It's not necessary to pass all customer fields along with the PATCH request. Instead, you can only add those fields with new or changed data. All other customer fields will remain unchanged.
 
 !!! warning
-    In most frameworks, the e-mail address is used as unique identifier and therefore, **customer.code** and **customer.email** should contain the same value if both are sent within the request. Otherwise, this may lead to inconsistencies when using different frameworks as host application.
+    In most frameworks the e-mail address is used as unique identifier. Therefore, **customer.code** and **customer.email** should contain the same value if both are sent within the request. Otherwise, this may lead to inconsistencies when using different frameworks as host application.
 
 # Delete customer
 
-It's also possible to delete a user account and remove all associated data like addresses but except orders. All order related data will stay untouched because it's only loosely related to customer accounts and must be available for accounting reasons.
+It's also possible to delete a user account and remove all associated data (like addresses), except orders. All order related data will stay untouched because it's only loosely related to customer accounts and must be available for accounting reasons.
 
-Every user can only delete his own account and he must be logged in to do so.
+Every user can only delete his own account and she/he must be logged in to do so.
 
 !!! tip
-    How to authenticate the user depends on the used PHP framework. Please have a look into the documentation of your used framework, e.g. at Laravel [Passport](https://laravel.com/docs/master/passport)/[Sanctum](https://laravel.com/docs/master/sanctum) or Symfony [Guard](https://symfony.com/doc/current/security/guard_authentication.html).
+    The way a user is authenticated depends very much on the PHP framework you use. Please have a look at the documentation of the respective framework of your choice, e.g. at Laravel [Passport](https://laravel.com/docs/master/passport)/[Sanctum](https://laravel.com/docs/master/sanctum) or Symfony [Guard](https://symfony.com/doc/current/security/guard_authentication.html).
 
 For deleting the account use e.g.:
 

--- a/src/frontend/jsonapi/index.md
+++ b/src/frontend/jsonapi/index.md
@@ -1,10 +1,10 @@
 Since 2017.04, Aimeos contains a front-end JSON API modeled after the guidelines of <https://jsonapi.org/>. It enables you to view and order products via mobile apps or create JavaScript applications to access to any Aimeos based online shop using a single look and feel.
 
-The entry point to access the Aimeos JSON API depends on the host application you use (Laravel, Symphony, TYPO3). You have to retrieve the initial base URL from a configuration setting or somewhere else. The resource URLs are different depending on the environment, but you can get the available ones by querying the meta data from the base URL (via the HTTP OPTIONS method).
+The entry point to access the Aimeos JSON API depends on the host application you use (Laravel, Symfony, TYPO3). You have to retrieve the initial base URL from a configuration setting or somewhere else. The resource URLs are different depending on the environment, but you can get the available ones by querying the meta data from the base URL (via the HTTP OPTIONS method).
 
 # Retrieve meta data
 
-The offered URLs to the resources depend on the application that hosts the Aimeos components. Therefore, you can't use fixed URLs like `http://localhost:8000/jsonapi/product?id=1`. Instead, you need to configure the base URL to the Aimeos JSON API of the instance you want to connect to in your client application. Afterwards, you must use the OPTIONS method to retrieve the service description with the list of resources and their URLs, e.g.
+The offered URLs to the resources depend on the application that hosts the Aimeos components. Therefore, you can't use fixed URLs like `http://localhost:8000/jsonapi/product?id=1`. Instead you need to configure the base URL to the Aimeos JSON API of the instance you want to connect to in your client application. Afterwards you must use the OPTIONS method to retrieve the service description with the list of resources and their URLs, e.g.
 
 === "CURL"
     ```bash
@@ -20,7 +20,14 @@ The offered URLs to the resources depend on the application that hosts the Aimeo
     });
 
     promise.done( function( options ) {
-        var params = {};
+        var args = {};
+        var params;
+
+        if(options.meta.prefix) { // returned from OPTIONS call
+            params[options.meta.prefix] = args;
+        } else {
+            params = args;
+        }
 
         var result = $.ajax({
             method: "GET",
@@ -69,13 +76,13 @@ To handle this case correctly, you must embed the GET parameters into another ob
 
 === "Javascript"
     ```javascript
-    var paramsObj = {'resource': 'product', 'id': '1'};
-    var params
+    var args = {'resource': 'product', 'id': '1'};
+    var params;
 
     if( options.meta.prefix ) {
-        params[options.meta.prefix] = paramsObj;
+        params[options.meta.prefix] = args;
     } else {
-        params = paramsObj
+        params = args
     }
     ```
 

--- a/src/frontend/jsonapi/index.md
+++ b/src/frontend/jsonapi/index.md
@@ -1,10 +1,10 @@
 Since 2017.04, Aimeos contains a front-end JSON API modeled after the guidelines of <https://jsonapi.org/>. It enables you to view and order products via mobile apps or create JavaScript applications to access to any Aimeos based online shop using a single look and feel.
 
-There's also no common entry point to access the JSON API because it depends on the host application. You have to retrieve the initial base URL from a configuration setting or somewhere else. Also the resource URLs are different depending on the environment but you can get the available ones by querying the meta data from the base URL (via the HTTP OPTIONS method).
+The entry point to access the Aimeos JSON API depends on the host application you use (Laravel, Symphony, TYPO3). You have to retrieve the initial base URL from a configuration setting or somewhere else. The resource URLs are different depending on the environment, but you can get the available ones by querying the meta data from the base URL (via the HTTP OPTIONS method).
 
 # Retrieve meta data
 
-The offered URLs to the resources depend on the application that hosts the Aimeos components. Therefore, you can't use fixed URLs like `http://localhost:8000/jsonapi/product?id=1`. Instead, you need to configure the base URL to the Aimeos JSON API of the instance you  want to connect to in your client application. Afterwards, you must use the OPTIONS method to retrieve the service description with the list of resources and their URLs, e.g.
+The offered URLs to the resources depend on the application that hosts the Aimeos components. Therefore, you can't use fixed URLs like `http://localhost:8000/jsonapi/product?id=1`. Instead, you need to configure the base URL to the Aimeos JSON API of the instance you want to connect to in your client application. Afterwards, you must use the OPTIONS method to retrieve the service description with the list of resources and their URLs, e.g.
 
 === "CURL"
     ```bash
@@ -55,7 +55,7 @@ It returns a JSON object containing the resources (those names are always the sa
 To access the products for example, you must lookup the URL for the "product" resource key. Similarly, you can use every key defined in the `resources` object to retrieve the corresponding items.
 
 !!! warning
-    Don't take the resource URLs in the OPTIONS response as granted! They will change depending on the routes and the application. Thus, your client needs the OPTIONS URL of the JSON REST API as configuration parameter. It's response will define the next possibilities.
+    Don't take the resource URLs in the OPTIONS response as granted! They will change depending on the routes and the application. Thus, your client needs the OPTIONS URL of the JSON REST API as configuration parameter. Its response will define the next possibilities.
 
 # Nested parameters
 
@@ -69,10 +69,13 @@ To handle this case correctly, you must embed the GET parameters into another ob
 
 === "Javascript"
     ```javascript
-    var params = {'resource': 'product', 'id': '1'};
+    var paramsObj = {'resource': 'product', 'id': '1'};
+    var params
 
     if( options.meta.prefix ) {
-        params[options.meta.prefix] = params;
+        params[options.meta.prefix] = paramsObj;
+    } else {
+        params = paramsObj
     }
     ```
 

--- a/src/frontend/jsonapi/index.md
+++ b/src/frontend/jsonapi/index.md
@@ -21,7 +21,7 @@ The offered URLs to the resources depend on the application that hosts the Aimeo
 
     promise.done( function( options ) {
         var args = {};
-        var params;
+        var params = {};
 
         if(options.meta.prefix) { // returned from OPTIONS call
             params[options.meta.prefix] = args;
@@ -77,7 +77,7 @@ To handle this case correctly, you must embed the GET parameters into another ob
 === "Javascript"
     ```javascript
     var args = {'resource': 'product', 'id': '1'};
-    var params;
+    var params = {};
 
     if( options.meta.prefix ) {
         params[options.meta.prefix] = args;

--- a/src/frontend/jsonapi/orders.md
+++ b/src/frontend/jsonapi/orders.md
@@ -1,4 +1,4 @@
-Creating orders requires a complete basket, i.e. it contains at least one product, the billing address and a payment and delivery entry. Then, it's a three way step to create the required database entries and redirect to the payment gateway or the thank you page.
+Creating orders requires a complete basket, i.e. it contains at least one product, the billing address and a payment and delivery entry. Then it's a three way step to create the required database entries and redirect to the payment gateway or the thank you page.
 
 # Save basket
 
@@ -126,7 +126,7 @@ After saving the basket, you need to create an order invoice. For this, you must
     });
     ```
 
-The response will contain the data of the created order invoice item as well as the link to the next step. This can be either the URL to the payment gateway or to the thank you page and you can find it in **response['links']['process']['href']**:
+The response will contain the data of the created order invoice item as well as the link to the next step. This can either be the URL to the payment gateway or to the thank you page and can be found in **response['links']['process']['href']**:
 
 ```json
 {
@@ -222,7 +222,7 @@ select
 : Select drop-down (with options from "default" property)
 
 
-The "code" contains the form parameter name and the "default" property the value that should be sent to the payment gateway. For all entries in the "meta" section with "public" equals "true", you have to show the customer a corresponding input field where they can enter e.g. their credit card number. All entries with "public" is "false" must be added as hidden input elements:
+The "code" contains the form parameter name and the "default" property value that should be sent to the payment gateway. For all entries in the "meta" section with "public" equals "true", you have to show the customer a corresponding input field where they can enter e.g. their credit card number. All entries with "public" is "false" must be added as hidden input elements:
 
 === "jQuery"
     ```javascript
@@ -288,12 +288,15 @@ as *include* parameter:
     ```
 === "jQuery"
     ```javascript
-    var params = {
+    var args = {
         include: "order/base/address,order/base/coupon,order/base/product,order/base/service"
     };
+    var params;
 
     if(options.meta.prefix) { // returned from OPTIONS call
-        params[options.meta.prefix] = params;
+        params[options.meta.prefix] = args;
+    } else {
+        params = args;
     }
 
     $.ajax({

--- a/src/frontend/jsonapi/orders.md
+++ b/src/frontend/jsonapi/orders.md
@@ -291,7 +291,7 @@ as *include* parameter:
     var args = {
         include: "order/base/address,order/base/coupon,order/base/product,order/base/service"
     };
-    var params;
+    var params = {};
 
     if(options.meta.prefix) { // returned from OPTIONS call
         params[options.meta.prefix] = args;

--- a/src/frontend/jsonapi/reviews.md
+++ b/src/frontend/jsonapi/reviews.md
@@ -27,34 +27,35 @@ It also returns the [prefix](index.md#nested-parameters) you have to use if the 
 
 ```json
 {
-"meta": {
-    "prefix": null,
-    "filter": {
-        "f_domain": {
-            "label": "Return reviews for that domain, e.g. 'product'",
-            "type": "string",
-            "default": "product",
-            "required": false
+    "meta": {
+        "prefix": null,
+        "filter": {
+            "f_domain": {
+                "label": "Return reviews for that domain, e.g. 'product'",
+                "type": "string",
+                "default": "product",
+                "required": false
+            },
+            "f_refid": {
+                "label": "Return reviews for the item from the domain with that ID",
+                "type": "string",
+                "default": null,
+                "required": false
+            }
         },
-        "f_refid": {
-            "label": "Return reviews for the item from the domain with that ID",
-            "type": "string",
-            "default": null,
-            "required": false
-        }
-    },
-    "sort": {
-        "ctime": {
-            "label": "Sort reviews by creation date/time",
-            "type": "string",
-            "default": true,
-            "required": false
-        },
-        "ctime": {
-            "label": "Sort reviews by rating",
-            "type": "string",
-            "default": false,
-            "required": false
+        "sort": {
+            "ctime": {
+                "label": "Sort reviews by creation date/time",
+                "type": "string",
+                "default": true,
+                "required": false
+            },
+            "ctime": {
+                "label": "Sort reviews by rating",
+                "type": "string",
+                "default": false,
+                "required": false
+            }
         }
     }
 }

--- a/src/frontend/jsonapi/reviews.md
+++ b/src/frontend/jsonapi/reviews.md
@@ -75,7 +75,7 @@ Now you can retrieve reviews via the "review" resource you've just received from
             'f_refid': '1'
         }
     };
-    var params;
+    var params = {};
 
     if(options.meta.prefix) { // returned from OPTIONS call
         params[options.meta.prefix] = args;
@@ -149,7 +149,7 @@ In addition to the generic filter possibilities, you can sort reviews by these k
 === "jQuery"
     ```javascript
     var args = {'sort': '-rating'};
-    var params;
+    var params = {};
 
     if(options.meta.prefix) { // returned from OPTIONS call
         params[options.meta.prefix] = params;

--- a/src/frontend/jsonapi/reviews.md
+++ b/src/frontend/jsonapi/reviews.md
@@ -1,4 +1,4 @@
-Before you can retrieve the reviews, you must get the resource endpoint via the OPTIONS request. Depending on the used routes it might be something like:
+Before you can retrieve the reviews, you must get the resource endpoint via the OPTIONS request. Depending on the used routes it might be something like this:
 
 ```bash
 curl -X OPTIONS 'http://localhost:8000/jsonapi'
@@ -31,7 +31,7 @@ It also returns the [prefix](index.md#nested-parameters) you have to use if the 
     "prefix": null,
     "filter": {
         "f_domain": {
-            "label": "Return reviews for that domain, e.g. "product"",
+            "label": "Return reviews for that domain, e.g. 'product'",
             "type": "string",
             "default": "product",
             "required": false
@@ -62,7 +62,7 @@ It also returns the [prefix](index.md#nested-parameters) you have to use if the 
 
 # Fetch reviews
 
-Now you can retrieve reviews via the "review" resource you've got from the OPTIONS response. By default, the list of all product reviews is returned and you should filter them by the ID of the product the user requested, e.g.:
+Now you can retrieve reviews via the "review" resource you've just received from the OPTIONS response. By default, the list of all product reviews is returned and you should filter them by the ID of the product the user requested, e.g.:
 
 === "CURL"
     ```bash
@@ -70,12 +70,17 @@ Now you can retrieve reviews via the "review" resource you've got from the OPTIO
     ```
 === "jQuery"
     ```javascript
-    var params = {filter: {
-        'f_refid': '1'
-    }};
+    var args = {
+        filter: {
+            'f_refid': '1'
+        }
+    };
+    var params;
 
     if(options.meta.prefix) { // returned from OPTIONS call
-        params[options.meta.prefix] = params;
+        params[options.meta.prefix] = args;
+    } else {
+        params = args;
     }
 
     $.ajax({
@@ -132,7 +137,7 @@ This response contains all reviews for the product with the ID "1":
 
 # Sort reviews
 
-Additional to the generic filter possibilities, you can sort reviews by these keys:
+In addition to the generic filter possibilities, you can sort reviews by these keys:
 
 * "ctime" (asc) or "-ctime" (desc)
 * "rating" (asc) or "-rating" (desc)
@@ -143,10 +148,13 @@ Additional to the generic filter possibilities, you can sort reviews by these ke
     ```
 === "jQuery"
     ```javascript
-    var params = {'sort': '-rating'};
+    var args = {'sort': '-rating'};
+    var params;
 
     if(options.meta.prefix) { // returned from OPTIONS call
         params[options.meta.prefix] = params;
+    } else {
+        params = args;
     }
 
     $.ajax({


### PR DESCRIPTION
UPDATE 2020-09-07: Ready for review / merge.

------------

These fixes do not cover the whole documentation of the JSON API, but are rather an example upon which further steps will build.

I would like to have some feedback regarding the "nested object parameters" fix before I continue. See also index.md, very first jquery example: there the params object is empty. Should the code example be adopted to the fix like this (paramsObj and params remain empty):

```javascript
var url = ...
var promise = $.ajax( url, { });

promise.done( function( options ) {
    var paramsObj = {};
    var params;

    if(options.meta.prefix) { // returned from OPTIONS call
        params[options.meta.prefix] = paramsObj;
    } else {
        params = paramsObj;
    }

    var result = $.ajax({
        method: "GET",
        dataType: "json",
        url: options.meta.resources['product'],
        data: params
    });

    result.done( function( result ) {
        console.log( result.data );
    });
});
```

or should the "params" and "data" simply be left out (tested in TYPO3 9.5.20: works fine, fetches all products)?

```javascript
var url = ...
var promise = $.ajax( url, { ... });

promise.done( function( options ) {
    var result = $.ajax({
        method: "GET",
        dataType: "json",
        url: options.meta.resources['product']
    });
   ...
});
```

Also, most examples in the "basket" documentation sections do not mention a "params" object. (Haven't tested it, since I haven't reached that point in my leaning curve yet...)

Thank you!