### PR TITLE
For Discussion: Grammar, but also restructuring and removal of old text

### DIFF
--- a/src/infrastructure/schema-migrations.md
+++ b/src/infrastructure/schema-migrations.md
@@ -1,4 +1,4 @@
-In Aimeos, setup tasks are responsible for creating the database schema, updating the schema if necessary and migrating data required due to schema changes. They have to perform their tasks for all supported databases.
+In Aimeos, **[setup task](#setup-task)** are responsible for creating the database schema, updating the schema if necessary and migrating data required due to schema changes. They have to perform their tasks for all supported databases.
 
 The setup tasks have a lot of advantages and exceed the possibilities of other available solutions like ["Object-relational mapping" (ORM)](https://en.wikipedia.org/wiki/Object-relational_mapping) or similar alternatives to setup tasks:
 
@@ -48,14 +48,14 @@ return [
 },
 ```
 
-The files from the core contains an anonymous function that creates the table, adds the columns and indexes. An important detail is to return the updated schema. This object will then be passed to the anonymous function for the same table in your extension.
+An anonymous function creates the table and adds the columns as well as the indexes. An important detail is to return the updated schema. This object will then be passed to the anonymous function for the same table in your extension.
 
 !!! warning
     Please remember that identifiers (table/column/index names) must **not be longer then 30 characters**!
 
 ## Add new tables
 
-In your own extension, you have to create a PHP file with the same name as the file for the existing data domain, i.e. *attribute.php* in the *./lib/custom/setup/default/schema/* directory. This file can contain one or more anonymous functions for new tables of the same data domain. They are created exactly like in the Aimeos core, e.g.
+In your own extension you have to create a PHP file with the same name as the file for the existing data domain, i.e. *attribute.php* in the *./lib/custom/setup/default/schema/* directory. This file can contain one or more anonymous functions for new tables of the same data domain. They are created exactly like in the Aimeos core, e.g.
 
 ```php
 return [
@@ -85,12 +85,12 @@ return [
 
 ## Tables for new domains
 
-To create tables for a new data domain (not the existing ones like "attribute", "product", "service", etc.], then you need to create a setup task too. This setup task must extend from the existing MShopCreateTables (or MAdminCreateTables) setup task:
+In order to create tables for a new data domain (not existing ones like "attribute", "product", "service", etc.], you need to create a setup task, too. This setup task must extend from the existing `MShopCreateTables` and/or `MAdminCreateTables` setup task. E.g., for a new domain *mynewdomain* (defined in *setup/default/schema/mynewdomain.php*) create a file called *TablesCreateMynewdomain.php* with content similar to this one:
 
 ```php
 namespace Aimeos\MW\Setup\Task;
 
-class TablesCreateMydomain extends TablesCreateMShop
+class TablesCreateMynewdomain extends TablesCreateMShop
 {
     public function getPreDependencies()
     {
@@ -104,29 +104,26 @@ class TablesCreateMydomain extends TablesCreateMShop
 
     public function migrate()
     {
-        $this->msg( 'Creating base tables', 0, '' )
+        $this->msg( 'Creating mynewdomain tables', 0, '' )
         $ds = DIRECTORY_SEPARATOR;
 
         $files = [
-            'db-<mydomain>' => 'default' . $ds . 'schema' . $ds . '<mydomain>.php'
+            'db-mynewdomain' => 'default' . $ds . 'schema' . $ds . 'mynewdomain.php'
         ];
         $this->setupSchema( $files );
     }
 }
 ```
 
-In the *clean()* and *migrate()* methods, you have to call the *setupSchema()* method from the parent class with the file that contains your schema definition. For *clean()*, the second parameter must be *true* so DBAL will remove old tables, columns and indexes. The *$files* array contains the name of the database connection as key (*db* is used if *db-<mydomain>* isn't explicitely configured) and the relative path to the schema file.
-
-!!! note
-    Please replace **<mydomain>** and rename the class by the real name of your new domain.
+In the *migrate()* method, you have to call the *setupSchema()* method from the parent class with the file that contains your schema definition. The *$files* array contains the name of the database connection as key (*db* is used if *db-mynewdomain* isn't explicitely configured) and the relative path to the schema file.
 
 ## Modify existing tables
 
-It's possible to modify schema definitions of core tables in extensions. This enables your extension to add additional columns or indexes to core tables or change column options like their length or type. Your changes will be applied to the tables while the setup tasks are running as long as your extension is installed.
+It's possible to modify schema definitions of core tables via extensions. This enables your extension to add additional columns or indexes to core tables or change column options like their length or type. Your changes will be applied to the tables while the setup tasks are running as long as your extension is installed.
 
-You have to create a PHP file with the same name as the file for the existing data domain, i.e. attribute.php in the *./lib/custom/setup/default/schema/* directory - just like for adding a new table.
+You have to create a PHP file with the same name as the file for the existing data domain, i.e. *attribute.php* in the *./lib/custom/setup/default/schema/* directory - just like for adding a new table.
 
-The important difference to adding new tables is that the schema object already contains a table definition. You can retrieve the definition by using the *getTable()* method of the schema object. Afterwards, you can use the methods of the [table schema class](https://github.com/doctrine/dbal/blob/master/lib/Doctrine/DBAL/Schema/Table.php) to modify the table according to your needs, e.g.:
+The important difference compared to adding new tables is that the schema object already contains a table definition. You can retrieve the definition by using the *getTable()* method of the schema object. Afterwards, you can use the methods of the [table schema class](https://github.com/doctrine/dbal/blob/2.11.x/lib/Doctrine/DBAL/Schema/Table.php) (v2.11) to modify the table according to your needs, e.g.:
 
 ```php
 return [
@@ -170,31 +167,39 @@ return [
 );
 ```
 
-This will leave the index with the name *idx_msindte_value* untouched by DBAL if its part of a table in the same data domain.
+This will leave the index with the name *idx_msindte_value* untouched by DBAL if it is part of a table in the same data domain.
 
 # Setup process
 
 There can be several directories which contain *setup tasks*. The main directory inside the Aimeos core is *./lib/mshoplib/setup/*, which is configured in the *manifest.php* file. Extensions can provide setup tasks in their own directories as well, as long as they are also configured in their own *manifest.php* file.
 
-Each *setup task* can declare dependencies to other tasks, e.g. that a list of tasks must be executed before this task can run and that e.g. one task must be executed after the task completed. There will be more information about [pre- and post-dependencies](#dependencies) later as they require some more attention. The important thing during the setup process is that all tasks from all configured setup directories are sorted according to their dependencies and are executed in that order.
+Each *setup task* can declare dependencies to other tasks, e.g. a list of tasks must be executed before this task can run and one task must be executed after this task is completed. There will be more information about [pre- and post-dependencies](#dependencies) later as they require some more attention. The important thing during the setup process is that all tasks from all configured setup directories are sorted according to their dependencies and are executed in that order.
 
 ## Task types
 
-1.) Those, which declare no dependencies to other tasks and are not listed as post-dependencies in other tasks. There are only a few ones because usually, each task has one or more dependencies.
+1. Tasks that do not declare any dependencies to other tasks and are not listed as post-dependencies in other tasks. There are only a few such tasks, because usually each task has one or more dependencies.
 
-2.) Next are the tasks that depend on other tasks. Maybe they want to change columns that have been changed before by other tasks. New columns that should be inserted next to columns created by other tasks are another reason. In an empty database most of these setup tasks will exit immediately because the first check is always if the necessary database table exists. Therefore, the task for creating the tables is always executed after the ones changing tables in an existing database. This reduces the time for the setup process drastically for new installations.
+2. Tasks that depend on other tasks. Reasons for the dependencies can be (among others):
+  * changing columns that have been changed before by other tasks.
+  * creating new columns that should be inserted next to columns created by other tasks.
+  
+  In an empty database most of these setup tasks will exit immediately, because the first check is always, if the necessary database table exists. Therefore, the task for creating the tables is always executed after the ones changing tables in an existing database. This reduces the time for the setup process drastically for new installations.
 
-3.) The task for creating the tables and indexes is executed very late in the process. It reads the schema files in e.g. "./lib/mshoplib/setup/default/schema/" and executes the SQL statements if necessary.
+3. The task for creating the tables and indexes is executed very late in the process. It reads the schema files in e.g. "./lib/mshoplib/setup/default/schema/" and executes the SQL statements if necessary.
 
-4.) Tasks executed afterwards either need the new tables for migrating data from old ones or they will insert records into those tables. There are tasks that insert some default records e.g. for the product types. Furthermore, some tasks are executed only for specific sites: The test sites ("unittest" and "unitperf") contain their own tasks that insert or generate the required test records. One of the last tasks is usually the one for rebuilding the index for fast search operations.
+4. Tasks executed afterwards either need the new tables for migrating data from old ones or they will insert records into those tables. There are tasks that insert some default records, e.g. for the product types. Furthermore, some tasks are executed only for specific sites: The test sites ("unittest" and "unitperf") contain their own tasks that insert or generate the required test records. One of the last tasks is usually the one for rebuilding the index for fast search operations.
 
-Each task tests if the part of the database schema that it's written for is already up to date and prints what tables it checks. If nothing has to be done, it will only print "OK". Otherwise, it performs the necessary changes and tell you what has been done.
+Each task tests if the part of the database schema that it is written for is already up-to-date and prints what tables it checks. If nothing has to be done, it will only print "OK". Otherwise, it performs the necessary changes and tells you what has been done.
+
+# Anatomy of *setup tasks*
+
+The following section describes, where *setup tasks* are stored and how they have to be written.
 
 ## Basics
 
-The setup tasks that are part of the Aimeos core are stored in the *./lib/mshoplib/setup/* directory. Tasks only relevant for a specific site (like for unit tests or performance tests) are located in subdirectories named after the site, i.e. *./lib/mshoplib/setup/default/*,  *"*./lib/mshoplib/setup/unittest/* or  *./lib/mshoplib/setup/unitperf/*.
+The *setup tasks* that are part of the *Aimeos core* are stored in the *./lib/mshoplib/setup/* directory. Tasks only relevant for a specific site (like for unit tests or performance tests) are located in subdirectories named after the site, i.e. *./lib/mshoplib/setup/default/*,  *"*./lib/mshoplib/setup/unittest/* or  *./lib/mshoplib/setup/unitperf/*.
 
-In the Aimeos extensions resp. your own extension, setup tasks should be in the **./lib/custom/setup/** directory or in one of the subdirectories for a specific site. You can configure the path where the setup manager is looking for tasks that should be executed within the *manifest.php* file of your extension.
+In the Aimeos extensions resp. your own extension, *setup tasks* should be in the **./lib/custom/setup/** directory or in one of the subdirectories for a specific site. You can configure the path, where the setup manager should look for tasks, that should be executed, within the *manifest.php* file of your extension.
 
 ```php
 return [
@@ -209,7 +214,7 @@ The "setup" key can contain a list of paths relative to the base path of the ext
 
 ## Naming
 
-The name of a setup task should be as specific as possible and must be unique across all extensions! The default naming scheme for tasks in the Aimeos core is:
+The name of a *setup task* should be as specific as possible and must be unique across *all extensions*! The default naming scheme for tasks in the Aimeos core is:
 
 ```
 <domain><action>[<subdomain>]<what>
@@ -222,14 +227,14 @@ Good examples are:
 * CustomerAddAddressFlagsColumn
 * ServiceMigrateTypeColumn
 
-Each task should only perform one action, like adding an index or dropping an index but not both at the same time. This enables a fine grained control over the dependencies between the tasks.
+Each task should only perform one action, like adding or dropping an index, but not both at the same time. This enables a fine grained control over the dependencies between the tasks.
 
 !!! warning
     Never add actions of separate domains to a single task, even if they do the same! The domains can be in separate databases and much more important: This can lead to circular dependencies easily!
 
 ## Structure
 
-The basic structure of a setup task looks like this. Please change the name of your setup task class according to the [naming schema](#naming).
+The basic structure of a *setup task* looks like this (please change the name of your *setup task* class according to the [naming schema](#naming)):
 
 ```php
 namespace Aimeos\MW\Setup\Task;
@@ -265,77 +270,81 @@ class TaskClassName extends \Aimeos\MW\Setup\Task\Base
 
 # Managing dependencies
 
-An essential part of setup tasks are the pre- and post-dependencies because they allow a very sophisticated ordering of the tasks. This is pretty unique across the available solutions because most of them are based on timestamps. This is OK if you have full control over your application but as soon as extensions will be able to modify the database schema too, it will break sooner or later.
+Crucial to *setup tasks* are the *pre-* and *post-dependencies* declarations, because they allow a very sophisticated ordering of tasks. This concept is pretty unique accross available software solutions out there in the www, because most of them are based on timestamps. A timestamp- or number-based system is OK as long as you have full control over your application, but as soon as extensions are able to modify the database schema, too, those solutions will break sooner or later.
 
-The setup tasks must be executed in a specific order to work correctly. Declaring the dependencies is a more flexible way to determine this order than using numbers, dates or the alphabetic order. As existing tasks shouldn't be changed to maintain full backward compatibility, it's necessary to allow new core setup tasks to declare which tasks must run before and which ones have to be executed afterwards.
+*Setup tasks* in *Aimeos* (which also allows extensions to change the database schema) execute in a specific order that is defined by declaring *pre* and *post* dependencies. *Pre-dependencies* are tasks that must be executed before the current *setup task* will run, while *post-dependencies* are tasks that will be invoked after the current *setup task* has finished executing.
 
-Also, extensions must be able to do the same because it wouldn't make sense for the core tasks to contain all dependencies of all existing extension tasks. The reason for extension setup tasks to be placed between core tasks is, that not only core tasks can create or update tables. If the setup task in your extension adds a column to a table it should be placed before the task which inserts the unit test data.
+This concept provides a more flexible way to determine a specific order than just using numbers, dates or the alphabet, which is relevant for at least two more reasons:
+
+1. Since existing tasks should not ever be changed in order to maintain full backward compatibility, it is necessary to allow *new* core setup tasks to declare, which tasks must run before and which ones have to be executed after the task itself.
+
+2. Extensions must be able to do the same, because it wouldn't make sense for the core tasks to contain all dependencies of all existing extension tasks. The reason for *extension setup tasks* to be placed between *core setup tasks* is that not only *core setup tasks* can create or update tables. If the *setup task* in your extension adds a column to a table, it should be placed before the task which inserts the unit test data.
 
 !!! note
     The name of the dependency is the class name, so for *Aimeos\MW\Setup\Task\TablesCreateMShop* it would be *TablesCreateMShop*. For this reason don't change the name of an existing task because then the required dependency information is lost.
 
 !!! warning
-    Only declare pre- and post-dependencies your task really depends on. Otherwise, the setup process will stop sooner or later because it can't resolve circular dependencies.
+    Only declare pre- and post-dependencies your task really depends on. Otherwise the setup process will stop sooner or later because it can't resolve circular dependencies.
 
 ## Pre-dependencies
 
-To find out which tasks must be executed before new ones, have a look at the SQL statements that should be executed. All tables, columns and indexes that are affected or referred by the statements should be taken into account when searching through the existing setup tasks. Most often you only have to look at the core tasks of the same domain to find all setup tasks that must be a pre-dependency to the new one.
+To find out which tasks must be executed before new ones, have a look at the SQL statements that should be executed. All tables, columns and indexes that are affected or referred to by the statements should be taken into account when searching through the existing *setup tasks*. Most often you only have to look at the core tasks of the same domain to find all setup tasks that must be a pre-dependency to the new one.
 
 Examples for pre-dependencies:
 
 * *OrderAddBaseAddressAddrId* depends on *OrderRenameTables* (the comment column is added to "mshop_order_base_address" but the original name of the table was "mshop_order_address")
-* *MShopAddLocaleData* depends on *TablesCreateMShop* (the languages and currencies can only inserted if the tables have been created)
+* *MShopAddLocaleData* depends on *TablesCreateMShop* (the languages and currencies can only be inserted, if the tables have been created)
 * *AttributeModifyIndex* has no dependencies (dropping the index if available depends on nothing else, especially not on the existence of the table itself)
 
 ## Post-dependencies
 
-Post-dependencies are a little bit different because you have to know what the task will do. Most often, post dependencies are used for the *TablesCreateMShop* and *CatalogRebuildIndex* or similar named tasks. The first one creates all new tables and indexes. Tasks modifying existing tables won't do anything if the tables are not yet available so adding *TablesCreateMShop* as post-dependency will speed up the process for new installations.
+Post-dependencies are a little bit different, because you have to know what the task will do. Most often, post dependencies are used for the *TablesCreateMShop* and *CatalogRebuildIndex* or similar named tasks. The first one creates all new tables and indexes. Tasks modifying existing tables won't do anything, if the tables are not yet available, so adding *TablesCreateMShop* as post-dependency will speed up the process for new installations.
 
 Examples for post-dependencies:
 
-* *CatalogAddCode* should run before *TablesCreateMShop* (to speed up the setup process)
-* *ProductAddTestData* should run before *CatalogRebuildIndex* (so the test products are written into the catalog index)
+* *CatalogAddIndexTypeCode* should run before *TablesCreateMShop* (to speed up the setup process)
+* *ProductAddTestData* should run before *CatalogRebuildTestIndex* (so the test products are written into the catalog index)
 
 # Helper methods
 
-As every setup task must extend the *Aimeos\MW\Setup\Task\Base* class, it inherits some methods that are required or useful to do the job. By using the base class, your task already implements the required interface *Aimeos\MW\Setup\Task\Iface*.
+As every *setup task* must extend the *Aimeos\MW\Setup\Task\Base* class, it inherits some methods that are required or useful to do the job. By using the base class, your task already implements the required interface *Aimeos\MW\Setup\Task\Iface*.
 
 ## Print messages
 
 msg( '<string>', <level> )
-: Prints the message indented by the given level. This method formats the messages so the output looks nice. Must be followed by a call to *$this->_status( '...' )*
+: Prints the message indented by the given level. This method formats the messages so the output looks nice. Must be followed by a call to *$this->_status( '...' )*.
 
 status( '<string>' )
-: Outputs the status for the test that was printed by *$this->_msg( ... )* before. Usual status values are: "OK" (nothing to do], "done" (task has been performed) or the number of records inserted ("<inserted>/<total>")
+: Outputs the status for the test that was printed by *$this->_msg( ... )* before. Usual status values are: "OK" (nothing to do], "Done" (task has been performed) or the number of records inserted ("<inserted>/<total>").
 
 ## Get schema/connection
 
 getSchema( '<database domain>' )
-: Retrieves the schema object for one of the databases. The parameter is one of the [[Developers/Several_databases|domains]] prefixed by "db-", e.g. "db-product"
+: Retrieves the schema object for one of the databases. The parameter is one of the [Developers/Several_databases|domains] prefixed by "db-", e.g. "db-product".
 
 getConnection( '<database domain>' )
-: Returns the connection object for one of the databases. The parameter is the same as for *getSchema()*
+: Returns the connection object for one of the databases. The parameter is the same as for *getSchema()*.
 
 ## Execute SQL statements
 
 execute( '<SQL statement>' )
 : Executes a single SQL statement
 
-executeList( <array of SQL statements> ): Executes a list of SQL statements in the order provided by the array. They are executed one by one and not inside of a transaction
+executeList( <array of SQL statements> ): Executes a list of SQL statements in the order provided by the array. They are executed one by one and not inside of a transaction.
 
 getValue( '<SQL statement>', '<column name>' )
-: Fetches a single record from the database and returns the value of the given column. If you need to fetch more than one record or column, use the database connection object instead
+: Fetches a single record from the database and returns the value of the given column. If you need to fetch more than one record or column, use the database connection object instead.
 
 ## Read platform specific SQL
 
 getTableDefinitions( <string> )
-: Extracts all table definitions from the given string (usually the content of a schema file). Each definition must be separated by two new lines ("\n")
+: Extracts all table definitions from the given string (usually the content of a schema file). Each definition must be separated by two new lines ("\n").
 
 getIndexDefinitions( <string> )
-: Extracts all index definitions from the given string (usually the content of a schema file). Each definition must be separated by two new lines ("\n")
+: Extracts all index definitions from the given string (usually the content of a schema file). Each definition must be separated by two new lines ("\n").
 
 getTriggerDefinitions( <string> )
-: Extracts all trigger definitions from the given string (usually the content of a schema file). Each definition must be separated by two new lines ("\n")
+: Extracts all trigger definitions from the given string (usually the content of a schema file). Each definition must be separated by two new lines ("\n").
 
 # Database schema
 
@@ -429,13 +438,13 @@ execute()
 ## Result methods
 
 affectedRows()
-: Returns the number of rows affected by a INSERT, UPDATE or DELETE statement
+: Returns the number of rows affected by an INSERT, UPDATE or DELETE statement
 
 fetch()
-: Retrieves the next row from database result set, returns false if no more rows are available
+: Retrieves the next row from a database result set, returns false if no more rows are available
 
 finish()
-: Cleans up pending database result sets. Must be always called after retrieving all rows or executing another statement
+: Cleans up pending database result sets. Must always be called after retrieving all rows or executing another statement.
 
 nextResult()
 : Retrieves next database result set if the SQL statement contained multiple statements

--- a/src/infrastructure/schema-migrations.md
+++ b/src/infrastructure/schema-migrations.md
@@ -300,10 +300,9 @@ Examples for pre-dependencies:
 
 Post-dependencies are a little bit different, because you have to know what the task will do. Most often, post dependencies are used for the *TablesCreateMShop* and *CatalogRebuildIndex* or similar named tasks. The first one creates all new tables and indexes. Tasks modifying existing tables won't do anything, if the tables are not yet available, so adding *TablesCreateMShop* as post-dependency will speed up the process for new installations.
 
-Examples for post-dependencies:
+Example for post-dependencies (taken from *./lib/mshoplib/setup/MShopAddLocaleData.php*):
 
-* *CatalogAddIndexTypeCode* should run before *TablesCreateMShop* (to speed up the setup process)
-* *ProductAddTestData* should run before *CatalogRebuildTestIndex* (so the test products are written into the catalog index)
+* *MShopAddLocaleLangCurData* should run before *MShopSetLocale*
 
 # Helper methods
 
@@ -320,7 +319,7 @@ status( '<string>' )
 ## Get schema/connection
 
 getSchema( '<database domain>' )
-: Retrieves the schema object for one of the databases. The parameter is one of the [Developers/Several_databases|domains] prefixed by "db-", e.g. "db-product".
+: Retrieves the schema object for one of the databases. The parameter is one of the [domains](database.md#multiple-databases) prefixed by "db-", e.g. "db-product".
 
 getConnection( '<database domain>' )
 : Returns the connection object for one of the databases. The parameter is the same as for *getSchema()*.
@@ -458,7 +457,7 @@ $stmt = $conn->create( 'SELECT * FROM my_table WHERE type = ?' );
 $stmt->bind( 1, 'payment' );
 $result = $stmt->execute();
 
-while( ( $row = $result->fetch() ) !# false ) {
+while( $row = $result->fetch() ) {
     // process row
 }
 


### PR DESCRIPTION
Please do not merge yet.

1. Grammar fixes.
 
2. Introduce a new section "Anatomy of a setup task"
The "Setup process" is very confusing. I thought, maybe splitting some parts into a new section "Anatomy of ..." helps to focus the mindset to the proper intention of the Docu?

3. Fix link to git doctrine DBAL for "Schema/Table" function.
Doctrine is now in v3, which changed the folder structure. Therefore it is now linked to v2.11.

4. Remove reference to "clean()" function, which was removed in https://github.com/aimeos/aimeos-core/commit/46d9e1121d821704dc77a9183fd9c275736e8b80

It remains unclear, what the proper names for the setup task examples are in Line 305ff.

The same is true for Line 323, where brackets seem to want to lead to another file...