### PR TITLE
Emphasize to assign templates using slash notation

### DIFF
--- a/src/typo3/customize.md
+++ b/src/typo3/customize.md
@@ -47,6 +47,15 @@ plugin.tx_aimeos.settings.client.html.catalog.lists.domains {
 }
 ```
 
+!!! warning "Be extra careful with template assignments!"
+    In the case of assigning templates to a plugin (e.g. via the Typoscript Configuration field in a plugin's flexform), the dot-notation only applies to the **left-hand side** of the equation! The **right-hand site**, the relative path to the template, still has to be written **with slashes**!
+
+    **Example:**
+    
+    ```typoscript
+    client.html.catalog.lists.standard.template-body = catalog/lists/body-myspeciallayout
+    ```
+
 ## Per Plugin
 
 Several plugins provide the possibility to add plug-in specific TypoScript configuration in the "Plugin" tab of the plug-ins placed on a page. Use the configuration keys from the documentation as in the example below:

--- a/src/typo3/customize.md
+++ b/src/typo3/customize.md
@@ -1,18 +1,27 @@
 # Change configuration
 
-There are a lot of configuration options available and documented in the *Configuration* section.
-
-## Frontend
-
-To add or overwrite configuration options in TYPO3, you can use TypoScript. Simply add the new or overwritten configuration values to the setup section of a page TypoScript template.
-
-The keys in the configuration documentation are always in the form of:
+There are a lot of configuration options available and documented in the *Configuration* section. The keys in the configuration documentation are always in the form of:
 
 ```
 client/html/catalog/filter/default/button = 1
 ```
 
-To use such a key with TypoScript, replace the slashes (/) with dots (.) and prepend "plugin.tx_aimeos.settings.":
+As a rule of thumb, replace the slashes (/) with dots (.) to use such keys in TypoScript:
+
+```typoscript
+client.html.catalog.filter.default.button = 1
+```
+
+!!! warning
+    Don't for get **prefixes** necessary for frontend and backend settings! Also, the dot-notation only applies to the key on the **left-hand side** of the equal sign, not to the value on the right side, i.e.
+    
+    ```typoscript
+    client.html.catalog.lists.standard.template-body = catalog/lists/body-mytemplate
+    ```
+
+## Frontend
+
+To add or overwrite configuration options in TYPO3, you can use TypoScript. Simply add the new or overwritten configuration values to the setup section of a page TypoScript template, e.g.:
 
 ```typoscript
 plugin.tx_aimeos.settings.client.html.catalog.filter.default.button = 1
@@ -46,15 +55,6 @@ plugin.tx_aimeos.settings.client.html.catalog.lists.domains {
     }
 }
 ```
-
-!!! warning "Be extra careful with template assignments!"
-    In the case of assigning templates to a plugin (e.g. via the Typoscript Configuration field in a plugin's flexform), the dot-notation only applies to the **left-hand side** of the equation! The **right-hand site**, the relative path to the template, still has to be written **with slashes**!
-
-    **Example:**
-    
-    ```typoscript
-    client.html.catalog.lists.standard.template-body = catalog/lists/body-myspeciallayout
-    ```
 
 ## Per Plugin
 
@@ -91,14 +91,14 @@ It doesn't make sense to assign all frontend settings to the backend module, too
 All scheduler tasks allow adding specific TypoScript configuration for the jobs that should be executed. This is especially useful for setting or overwriting configuration values for e-mails that should be sent to customers. Use the configuration keys from the documentation like this:
 
 ```typoscript
-client.html.common.content.baseurl = https://yourdomain/uploads/tx_aimeos
+client.html.email.payment.standard.template-body = email/payment/body-standard
 ```
 
 The same works with arrays of values as well:
 
 ```typoscript
 client.html {
-    common.content.baseurl = https://yourdomain/uploads/tx_aimeos
+    email.payment.standard.template-body = email/payment/body-standard
 }
 controller.jobs.order.email.payment.default.status {
     0 = 5


### PR DESCRIPTION
In the course of re-writing slash- to dot-notation in TypoScript, it might happen that the path to the template will also be changed to dot-notation, which would be wrong. Therefor a little warning block with an example points out to pay extra attention, when it comes to template (re-)assignment.