### PR TITLE
[Prospoal] Add description on how to configure the CKEditor

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -138,6 +138,7 @@ nav:
       - Panel templates: admin/jqadm/panel-templates.md
       - Create subparts: admin/jqadm/create-subparts.md
       - Extend panels: admin/jqadm/extend-panels.md
+      - Customize: admin/jqadm/customize.md
     - JsonAdm API:
       - Overview: admin/jsonadm/index.md
       - Retrieve metadata: admin/jsonadm/metadata.md

--- a/src/admin/jqadm/customize.md
+++ b/src/admin/jqadm/customize.md
@@ -49,13 +49,13 @@ This would only be the first step, though, since neither the text align nor the 
 In order to make buttons like the text align options (JustifyLeft, JustifyCenter, JustifyRight, JustifyBlock) visible, you may have to add a plugin, in this case the *justify* plugin, to the *extraPlugins* option:
 
 ```javascript
-Aimeos.extraPlugins = 'devarea,justify'
+Aimeos.extraPlugins = 'divarea,justify'
 ```
 
 Now the text align options will be visible except for *JustifyBlock*, which is removed by default by the *removeButtons* option. (See below.)
 
 !!! note
-    Please note that the standard configuration is `Aimeos.extraPlugins = 'devarea'`. `devarea` is a CKEditor plugin that renders the CKEditor in a div tag instead of in an iframe. We recommend to not remove it!
+    Please note that the standard configuration is `Aimeos.extraPlugins = 'divarea'`. `divarea` is a CKEditor plugin that renders the CKEditor in a div tag instead of in an iframe. We recommend to not remove it!
 
 ## Manage removed buttons
 

--- a/src/admin/jqadm/customize.md
+++ b/src/admin/jqadm/customize.md
@@ -2,7 +2,10 @@
 
 Aimeos currently implements the *CKEditor v4 Standard All Edition* via [jsdelivr](https://www.jsdelivr.com/) which hosts the npm version (https://www.npmjs.com/package/ckeditor4). This version comes with all standard plugins activated and all *official* plugins included, but deactivated. The standard configuration is ruled by CKEditor's  [Allowed Content Rules](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_allowed_content_rules.html) which, by default, hides some buttons (e.g. "superscript", "subscript"), something to be aware of, when it comes to configuration.
 
-## Configure CKEditor in *custom.js*
+!!! note
+    CKEditor configuraton works since v2020.7.10-dev.
+
+## Configure CKEditor via *custom.js*
 
 Your aimeos extensions includes a *custom.js* script which allows you to configure CKEditor. 
 
@@ -23,12 +26,11 @@ Aimeos.editorcfg = [
 ]
 ```
 
-This configuration will be merged in the global Aimeos configuration and, since it is currently not possible to create an individual configuration for a specific text field, applied to all available text fields of all domains.
+This configuration will be merged into the global *Aimeos* configuration and applied to all available text fields of all domains. (Configuration for specific text fields is currently not available.)
 
-If you wish to add buttons like super- and/or subscript or activate text align options, you have to extend your configuration like this:
+If you wish to activate certain buttons, e.g. for super- and/or subscript, or add e.g. text align options, you have to extend your configuration like this:
   
 ```javascript
-// Override the toolbar options
 Aimeos.editorcfg = [
   [ 'Undo', 'Redo' ],
   [ 'Link', 'Unlink', 'Anchor' ],
@@ -40,29 +42,32 @@ Aimeos.editorcfg = [
 ]
 ```
 
-but this would only be the first step, since the text editor's buttons would not be available yet. This is due to the fact that the *CKEditor v4 Standard Edition* disables additional plugins.
+This would only be the first step, though, since neither the text align nor the super-/subscript buttons would be available/visible yet. This is due to the fact that the *CKEditor v4 Standard Edition* disables additional plugins. (If you wish to activate other plugins or buttons like the ones mentioned here, please research the CKEditor website to find out, which plugins are offered by the *CKEditor v4 Standard Edition (from npm)* and which buttons are hidden by default.)
 
 ## Activate plugins
 
-In order to make the text align options visible, you need to add the *justify* plugin to the *extraPlugins* option:
+In order to make buttons like the text align options (JustifyLeft, JustifyCenter, JustifyRight, JustifyBlock) visible, you may have to add a plugin, in this case the *justify* plugin, to the *extraPlugins* option:
 
 ```javascript
-Aimeos.extraPlugins = ',justify'
+Aimeos.extraPlugins = 'devarea,justify'
 ```
 
-!!! warning
-    Please make sure to put a comma first! Otherwise the *Aimeos* standard configuration will break!
+Now the text align options will be visible except for *JustifyBlock*, which is removed by default by the *removeButtons* option. (See below.)
 
-Now the text align options will be visible.
+!!! note
+    Please note that the standard configuration is `Aimeos.extraPlugins = 'devarea'`. `devarea` is a CKEditor plugin that renders the CKEditor in a div tag instead of in an iframe. We recommend to not remove it!
 
 ## Manage removed buttons
 
-However, "Superscript" and "Subscript" are still not visible, because the *CKEDITOR v4 Standard Edition* removes these (and other) buttons. In order to make these buttons visible again, you need to configure the *removeButtons* option:
+Buttons like "Superscript" and "Subscript" are not visible, because the *CKEDITOR v4 Standard Edition* removes them (and others) by default. In order to make such buttons visible again, you need to configure the *removeButtons* option:
 
 ```javascript
 Aimeos.removeButtons = ''
 ```
 
+!!! note
+    Please note that the standard configuration is `Aimeos.removeButtons = 'Superscript,Subscript,JustifyBlock,Underline'`.
+
 ## Add external CSS
 
-Adding styles via an external CSS file is currently not implemented by *Aimeos*.
+The option to add style via an external CSS file is currently not implemented.

--- a/src/admin/jqadm/customize.md
+++ b/src/admin/jqadm/customize.md
@@ -26,7 +26,7 @@ Aimeos.editorcfg = [
 ]
 ```
 
-This configuration will be merged into the global *Aimeos* configuration and applied to all available text fields of all domains. (Configuration for specific text fields is currently not available.)
+This configuration will be merged into the global *Aimeos* configuration and applied to all available text fields of all domains. (Individual configurations for specific text fields is currently not available.)
 
 If you wish to activate certain buttons, e.g. for super- and/or subscript, or add e.g. text align options, you have to extend your configuration like this:
   
@@ -52,21 +52,28 @@ In order to make buttons like the text align options (JustifyLeft, JustifyCenter
 Aimeos.extraPlugins = 'divarea,justify'
 ```
 
-Now the text align options will be visible except for *JustifyBlock*, which is removed by default by the *removeButtons* option. (See below.)
+Now the text align options will be visible.
 
 !!! note
-    Please note that the standard configuration is `Aimeos.extraPlugins = 'divarea'`. `divarea` is a CKEditor plugin that renders the CKEditor in a div tag instead of in an iframe. We recommend to not remove it!
+    Please note that the default configuration is `Aimeos.extraPlugins = 'divarea'`. `divarea` is a CKEditor plugin that renders the CKEditor in a div tag instead of in an iframe. We recommend to not remove it!
 
 ## Manage removed buttons
 
-Buttons like "Superscript" and "Subscript" are not visible, because the *CKEDITOR v4 Standard Edition* removes them (and others) by default. In order to make such buttons visible again, you need to configure the *removeButtons* option:
+Buttons like "Superscript" and "Subscript" are not visible, because the *CKEDITOR v4 Standard Edition* removes them (and others) by default. In order to make those buttons visible again, you need to configure the *removeButtons* option:
 
 ```javascript
 Aimeos.removeButtons = ''
 ```
 
 !!! note
-    Please note that the standard configuration is `Aimeos.removeButtons = 'Superscript,Subscript,JustifyBlock,Underline'`.
+    Please note that the default configuration is `Aimeos.removeButtons = 'Underline,Subscript,Superscript'`.
+
+## Manage allowed tags
+
+The `Aimeos.editortags` options allows you to add or remove tags.
+
+!!! note
+    The default configuration is `Aimeos.editortags = 'div(*);span(*);p(*);'`.
 
 ## Add external CSS
 

--- a/src/admin/jqadm/customize.md
+++ b/src/admin/jqadm/customize.md
@@ -1,0 +1,68 @@
+# Text Editor (CKEditor v4 Standard Edition)
+
+Aimeos currently implements the *CKEditor v4 Standard All Edition* via [jsdelivr](https://www.jsdelivr.com/) which hosts the npm version (https://www.npmjs.com/package/ckeditor4). This version comes with all standard plugins activated and all *official* plugins included, but deactivated. The standard configuration is ruled by CKEditor's  [Allowed Content Rules](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_allowed_content_rules.html) which, by default, hides some buttons (e.g. "superscript", "subscript"), something to be aware of, when it comes to configuration.
+
+## Configure CKEditor in *custom.js*
+
+Your aimeos extensions includes a *custom.js* script which allows you to configure CKEditor. 
+
+!!! note
+    If you decide to rename this file, make sure to also change the file reference in the *manifest.jsb2* file one folder level above!
+
+Initially this file is empty. To configure the editor, override the `Aimeos.editorcfg` object like this:
+
+```javascript
+// Override the toolbar options
+Aimeos.editorcfg = [
+  [ 'Undo', 'Redo' ],
+  [ 'Link', 'Unlink', 'Anchor' ],
+  [ 'Bold', 'Italic', 'Underline', 'Strike' ],
+  [ 'NumberedList', 'BulletedList', '-', 'Outdent', 'Indent', '-', 'Blockquote' ],
+  [ 'SpecialChar' ],
+  [ 'Source', '-', 'RemoveFormat' ]
+]
+```
+
+This configuration will be merged in the global Aimeos configuration and, since it is currently not possible to create an individual configuration for a specific text field, applied to all available text fields of all domains.
+
+If you wish to add buttons like super- and/or subscript or activate text align options, you have to extend your configuration like this:
+  
+```javascript
+// Override the toolbar options
+Aimeos.editorcfg = [
+  [ 'Undo', 'Redo' ],
+  [ 'Link', 'Unlink', 'Anchor' ],
+  [ 'JustifyLeft', 'JustifyCenter', 'JustifyRight' ],
+  [ 'Bold', 'Italic', 'Underline', 'Strike', 'Superscript', 'Subscript' ],
+  [ 'NumberedList', 'BulletedList', '-', 'Outdent', 'Indent', '-', 'Blockquote' ],
+  [ 'SpecialChar' ],
+  [ 'Source', '-', 'RemoveFormat' ]
+]
+```
+
+but this would only be the first step, since the text editor's buttons would not be available yet. This is due to the fact that the *CKEditor v4 Standard Edition* disables additional plugins.
+
+## Activate plugins
+
+In order to make the text align options visible, you need to add the *justify* plugin to the *extraPlugins* option:
+
+```javascript
+Aimeos.extraPlugins = ',justify'
+```
+
+!!! warning
+    Please make sure to put a comma first! Otherwise the *Aimeos* standard configuration will break!
+
+Now the text align options will be visible.
+
+## Manage removed buttons
+
+However, "Superscript" and "Subscript" are still not visible, because the *CKEDITOR v4 Standard Edition* removes these (and other) buttons. In order to make these buttons visible again, you need to configure the *removeButtons* option:
+
+```javascript
+Aimeos.removeButtons = ''
+```
+
+## Add external CSS
+
+Adding styles via an external CSS file is currently not implemented by *Aimeos*.

--- a/src/admin/jqadm/customize.md
+++ b/src/admin/jqadm/customize.md
@@ -1,18 +1,13 @@
-# Text Editor (CKEditor v4 Standard Edition)
+# CKEditor
 
-Aimeos currently implements the *CKEditor v4 Standard All Edition* via [jsdelivr](https://www.jsdelivr.com/) which hosts the npm version (https://www.npmjs.com/package/ckeditor4). This version comes with all standard plugins activated and all *official* plugins included, but deactivated. The standard configuration is ruled by CKEditor's  [Allowed Content Rules](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_allowed_content_rules.html) which, by default, hides some buttons (e.g. "superscript", "subscript"), something to be aware of, when it comes to configuration.
+Aimeos offers a rich text HTML editor in the text panels for adding HTML formatting to short and long descriptions and currently, the *CKEditor v4 Standard All Edition* is used. This version comes with all standard plugins activated and all *official* plugins included, but deactivated. The standard configuration hides some buttons (e.g. "superscript", "subscript"), something to be aware of, when it comes to configuration.
 
 !!! note
     CKEditor configuraton works since v2020.7.10-dev.
 
-## Configure CKEditor via *custom.js*
+## Customize
 
-Your aimeos extensions includes a *custom.js* script which allows you to configure CKEditor. 
-
-!!! note
-    If you decide to rename this file, make sure to also change the file reference in the *manifest.jsb2* file one folder level above!
-
-Initially this file is empty. If you want to customize CKEditor's *toolbar*, you can configure `Aimeos.editorcfg` like this:
+Your own Aimeos extensions includes a *./admin/jqadm/themes/custom.js* script which allows you to configure CKEditor. Initially this file is empty but you can add Javascript to overwrite the default HTML editor settings like this:
 
 ```javascript
 Aimeos.editorcfg = [
@@ -25,9 +20,32 @@ Aimeos.editorcfg = [
 ]
 ```
 
-This configuration will be merged into the global *Aimeos* configuration and applied to all available text fields of all domains. (Individual configurations for specific text fields is currently not available.)
+This configuration will replace the existing Aimeos configuration and will be applied to all available text area fields in all text panels.
 
-## Manage visibility of buttons
+### Activate plugins
+
+In order to make buttons like the text align options (JustifyLeft, JustifyCenter, JustifyRight, JustifyBlock) visible, you have to add a plugin to the *editorExtraPlugins* option, in this case the *justify* plugin:
+
+```javascript
+Aimeos.editorExtraPlugins = 'divarea,justify'
+```
+
+Now the text align options will be visible.
+
+!!! note
+    The default configuration contains `divarea` to render the CKEditor in a `div` tag instead of an `iframe`. We recommend to keep that plugin to avoid problems!
+
+## Allow HTML tags
+
+By default, CKEditor's [allowed content rules](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_allowed_content_rules.html) are used with the addition of those tags listed in the `Aimeos.editortags` configuration, which are assigned to CKEditor's *extraAllowedContent* setting. The Aimeos standard configuration is:
+
+```javascript
+Aimeos.editortags = 'div(*);span(*);p(*);';
+```
+
+The `Aimeos.editortags` option enables you to configure more tags which are allowed in the source view, replace them by your own list or remove them completely. The format of the setting must be the tag name, followed by the list of CSS classes in round brackets or "\*" for all classes. Each tags/class combination must contain a semicolon at the end. Don't use spaces anywhere in the string!
+
+## Show more buttons
 
 If you wish to activate certain buttons, e.g. for super- and/or subscript, or add e.g. text align options, extend your configuration like this:
   
@@ -43,39 +61,20 @@ Aimeos.editorcfg = [
 ]
 ```
 
-This would only be the first step, though, since neither the text align nor the super-/subscript buttons would be available/visible yet. This is due to the fact that the *CKEditor v4 Standard Edition* disables additional plugins by default as well as removes some buttons. (If you wish to activate other plugins or buttons like the ones mentioned here, please research the CKEditor website to find out, which plugins are offered by the *CKEditor v4 Standard Edition (from npm)* and which buttons are hidden by default.)
+This would only be the first step, though, since neither the text align nor the super-/subscript buttons would be available/visible yet. This is due to the fact that the *CKEditor v4 Standard Edition* disables additional plugins by default as well as removes some buttons.
 
-### Activate plugins
+### Remove buttons
 
-In order to make buttons like the text align options (JustifyLeft, JustifyCenter, JustifyRight, JustifyBlock) visible, you have to add a plugin to the *editorExtraPlugins* option, in this case the *justify* plugin:
-
-```javascript
-Aimeos.editorExtraPlugins = 'divarea,justify'
-```
-
-Now the text align options will be visible.
-
-!!! note
-    Please note that the default configuration is `Aimeos.editorExtraPlugins = 'divarea'`. `divarea` is a CKEditor plugin that renders the CKEditor in a div tag instead of an iframe. We recommend to not remove it!
-
-### Manage removed buttons
-
-Buttons like "Superscript" and "Subscript" are not visible, because the *CKEDITOR v4 Standard Edition* removes them (and others) by default. In order to make these buttons visible again, you need to configure the *editorRemoveButtons* option:
+The buttons for "Underline", "Superscript" and "Subscript" are not visible, because the *CKEDITOR v4 Standard Edition* removes them by default. You can change the list of buttons using the `Aimeos.editorRemoveButtons` setting. The default configuration in Aimeos is:
 
 ```javascript
-Aimeos.editorRemoveButtons = ''
+Aimeos.editorRemoveButtons = 'Underline,Subscript,Superscript';
 ```
 
-!!! note
-    Please note that the default configuration is `Aimeos.editorRemoveButtons = 'Underline,Subscript,Superscript'`.
+The button names must be separated by comma. To show all buttons, set the configuration option to an empty string:
 
-## Manage allowed tags
+```javascript
+Aimeos.editorRemoveButtons = '';
+```
 
-The `Aimeos.editortags` options allows you to add or remove tags. It is used to configure CKEditor's *extraAllowedContent* option.
-
-!!! note
-    The default configuration is `Aimeos.editortags = 'div(*);span(*);p(*);'`.
-
-## Add external CSS
-
-The option to add styles via an external CSS file is currently not implemented.
+There's a complete [list of CKEditor button names](https://ckeditor.com/old/forums/CKEditor/Complete-list-of-toolbar-items#comment-123266) available for reference.

--- a/src/admin/jqadm/customize.md
+++ b/src/admin/jqadm/customize.md
@@ -12,10 +12,9 @@ Your aimeos extensions includes a *custom.js* script which allows you to configu
 !!! note
     If you decide to rename this file, make sure to also change the file reference in the *manifest.jsb2* file one folder level above!
 
-Initially this file is empty. To configure the editor, override the `Aimeos.editorcfg` object like this:
+Initially this file is empty. If you want to customize CKEditor's *toolbar*, you can configure `Aimeos.editorcfg` like this:
 
 ```javascript
-// Override the toolbar options
 Aimeos.editorcfg = [
   [ 'Undo', 'Redo' ],
   [ 'Link', 'Unlink', 'Anchor' ],
@@ -28,12 +27,14 @@ Aimeos.editorcfg = [
 
 This configuration will be merged into the global *Aimeos* configuration and applied to all available text fields of all domains. (Individual configurations for specific text fields is currently not available.)
 
-If you wish to activate certain buttons, e.g. for super- and/or subscript, or add e.g. text align options, you have to extend your configuration like this:
+## Manage visibility of buttons
+
+If you wish to activate certain buttons, e.g. for super- and/or subscript, or add e.g. text align options, extend your configuration like this:
   
 ```javascript
 Aimeos.editorcfg = [
-  [ 'Undo', 'Redo' ],
-  [ 'Link', 'Unlink', 'Anchor' ],
+  [ 'Undo', 'Redo', 'Anchor' ],
+  [ 'Link', 'Unlink' ],
   [ 'JustifyLeft', 'JustifyCenter', 'JustifyRight' ],
   [ 'Bold', 'Italic', 'Underline', 'Strike', 'Superscript', 'Subscript' ],
   [ 'NumberedList', 'BulletedList', '-', 'Outdent', 'Indent', '-', 'Blockquote' ],
@@ -42,39 +43,39 @@ Aimeos.editorcfg = [
 ]
 ```
 
-This would only be the first step, though, since neither the text align nor the super-/subscript buttons would be available/visible yet. This is due to the fact that the *CKEditor v4 Standard Edition* disables additional plugins. (If you wish to activate other plugins or buttons like the ones mentioned here, please research the CKEditor website to find out, which plugins are offered by the *CKEditor v4 Standard Edition (from npm)* and which buttons are hidden by default.)
+This would only be the first step, though, since neither the text align nor the super-/subscript buttons would be available/visible yet. This is due to the fact that the *CKEditor v4 Standard Edition* disables additional plugins by default as well as removes some buttons. (If you wish to activate other plugins or buttons like the ones mentioned here, please research the CKEditor website to find out, which plugins are offered by the *CKEditor v4 Standard Edition (from npm)* and which buttons are hidden by default.)
 
-## Activate plugins
+### Activate plugins
 
-In order to make buttons like the text align options (JustifyLeft, JustifyCenter, JustifyRight, JustifyBlock) visible, you may have to add a plugin, in this case the *justify* plugin, to the *extraPlugins* option:
+In order to make buttons like the text align options (JustifyLeft, JustifyCenter, JustifyRight, JustifyBlock) visible, you have to add a plugin to the *editorExtraPlugins* option, in this case the *justify* plugin:
 
 ```javascript
-Aimeos.extraPlugins = 'divarea,justify'
+Aimeos.editorExtraPlugins = 'divarea,justify'
 ```
 
 Now the text align options will be visible.
 
 !!! note
-    Please note that the default configuration is `Aimeos.extraPlugins = 'divarea'`. `divarea` is a CKEditor plugin that renders the CKEditor in a div tag instead of in an iframe. We recommend to not remove it!
+    Please note that the default configuration is `Aimeos.editorExtraPlugins = 'divarea'`. `divarea` is a CKEditor plugin that renders the CKEditor in a div tag instead of an iframe. We recommend to not remove it!
 
-## Manage removed buttons
+### Manage removed buttons
 
-Buttons like "Superscript" and "Subscript" are not visible, because the *CKEDITOR v4 Standard Edition* removes them (and others) by default. In order to make those buttons visible again, you need to configure the *removeButtons* option:
+Buttons like "Superscript" and "Subscript" are not visible, because the *CKEDITOR v4 Standard Edition* removes them (and others) by default. In order to make these buttons visible again, you need to configure the *editorRemoveButtons* option:
 
 ```javascript
-Aimeos.removeButtons = ''
+Aimeos.editorRemoveButtons = ''
 ```
 
 !!! note
-    Please note that the default configuration is `Aimeos.removeButtons = 'Underline,Subscript,Superscript'`.
+    Please note that the default configuration is `Aimeos.editorRemoveButtons = 'Underline,Subscript,Superscript'`.
 
 ## Manage allowed tags
 
-The `Aimeos.editortags` options allows you to add or remove tags.
+The `Aimeos.editortags` options allows you to add or remove tags. It is used to configure CKEditor's *extraAllowedContent* option.
 
 !!! note
     The default configuration is `Aimeos.editortags = 'div(*);span(*);p(*);'`.
 
 ## Add external CSS
 
-The option to add style via an external CSS file is currently not implemented.
+The option to add styles via an external CSS file is currently not implemented.


### PR DESCRIPTION
Configuring the CKEditor needs a little adjustment in the Vue component. here is why:

The current CKEditor version that is provided by Jsdelivr fetches its source from npm, which delivers the "CKEDitor v4 Standard Configuration", but with the "standard all" flag, which means, *all* non-community plugins are available, too, but currently deactivated. This leads to 2 "culprits":


* 1. Activating plugins must be enabled

Currently, if one wants to use the e.g. "text align" features (JustifyRight,Justifycenter...), she/he won't see any new buttons, because the plugin responsible for those functions, "justify", is deactivated. therefore, it is first necessary to enable the plugin "justify". 
(This plugin is ONLY available because the npm version delivers the "standard all" setup, as mentioned before. The "regular" standard version wouldn't provide this plugin, which is confusing, when consulting the CKEditor comparison page, e.g.)
The activation of this plugin is done via

`Aimeos.extraPlugins = 'justify'`

However, the current Vue component setup (line 157ff) already uses that configuration option to enable "divarea" (rendering of the text editor in a div instead of an iframe), and simply overriding it would most likely break the installation, since it is likely that the user forgets to add "divarea". Therefore I would suggest to override the vue component definition to sth like this:

```Vue Component
extraPlugins: 'divarea' + Aimeos.extraPlugins,
```

and instruct the user to use a comma in her/his configuration, like this:

`Aimeos.extraPlugins = ',justify'`


* 2. Enable "removeButtons"

Other buttons will not be visible, because the "Standard Configuration" removes "some buttons" (I couldn't find out, where it is documented, which buttons are removed; waiting for help on Stackoverflow). Buttons like "Superscript, Subscript" are affected by that feature. Overriding the "removeButtons" options is currently not available on the Vue component, which is, why I suggest to add it:

```javascript
// Vue-components.js
[...]
mounted: function() {
   this.instance = CKEDITOR.replace(this.id, {
        toolbar: Aimeos.editorcfg,
	extraPlugins: 'divarea' + Aimeos.extraPlugins,
	initialData: this.value,
	readOnly: this.readonly,
	protectedSource: [/\n/g],
	autoParagraph: false,
        entities: false,
	extraAllowedContent: 'div(*);span(*);p(*)' + Aimeos.editortags,
        removeButtons: Aimeos.removeButtons
   });
[...]

// Aimeos.js
Aimeos {
  extraPlugins: '',
  editortags : '',
  // trying to replicate the configuration from the Standard Edition
  removeButtons: 'Superscript,Subscript,JustifyBlock,Underline',
}
```

The user would simply configure

`Aimeos.removeButtons = ''`

or hide others... In this case this configuration would always be overridden and not concatenated.

I think it would be probably wise to do the same configuration with *extraAllowedContent* (already displayed in the code sample above).

I didn't dig into adding external CSS yet. ToDo...


* 3. Multiple configrations (no code in the PR, only for discussion)

I did think about enabling multiple CKEditor configurations and found this to be working so far:

```
mounted: function() {

    var editorConfig = (typeof Aimeos.editorcfg[this.id] !== 'undefined' && Aimeos.editorcfg[this.id] !== null)
      ? Aimeos.editorcfg[this.id]
      : (typeof Aimeos.editorcfg['base'] !== 'undefined' && Aimeos.editorcfg[this.id] !== null)
          ? Aimeos.editorcfg['base']
          : Aimeos.editorcfg

		this.instance = CKEDITOR.replace(this.id, {
```

This would allow for different configurations for each id, always falling back to a base configuration (the one that the user would define) or the Aimeos standard.

But this solution is based on id, which might be ok for the "Product" domain, but not for the "Supplier", e.g. I didn't find any tags in the HTML that describe which type of text field (name, short, long...) is used. If those were somehow available, the configurations could maybe be managed via text field type (one foe "Name", one for "Short"...)

Another option could be to add a column in the table overview of the items, which allows to assign a specific configuration for the text editor.

But... well... just thinking out loud...

* 4. Implementation of different CKEditor via TYPO3 Layout template Jqadm.html

Todo (would that be also in some way possible in Laravel and Symphony?)