### PR TITLE
Update example codes; unify spelling of "plugin"

### DIFF
--- a/src/manual/plugin-details.md
+++ b/src/manual/plugin-details.md
@@ -1,6 +1,6 @@
 ![Detail view for plug-ins](Admin-backend-plugin-detail.png)
 
-There are some select and input fields in the left section of the detail view that are all required. Their purpose are:
+There are some select and input fields in the left section of the detail view that are all required. Their purpose is:
 
 Status (required)
 : Controls the global availability of the configured plugin. There are several status values available but the plugin will only be used if the status is "enabled".
@@ -9,10 +9,10 @@ Type (required)
 : The plugin type, which can be only "Order" for basket plugins at the moment.
 
 Provider (required)
-: This is the last part of the plugin provider class name, e.g. "Shipping" for the "\Aimeos}MShop\Plugin\Provider\Order\Shipping". The name of the provider is **case sensitive**, so "shipping" is not the same as "Shipping"! Each plugin provider can be enhanced by one or more decorators that must be added to the provider name and separated by a comma. To configure the "Shipping" plugin provider in combination with e.g. a decorator called "Example", enter "Shipping,Example" into the input field of the provider. For a list of plugins and decorators that are part of the Aimeos core, please have a look at the [plugin overview](plugins.md).
+: This is the last part of the plugin provider class name, e.g. "Shipping" for the "\Aimeos\MShop\Plugin\Provider\Order\Shipping". The name of the provider is **case sensitive**, so "shipping" is not the same as "Shipping"! Each plugin provider can be enhanced by one or more decorators that must be added to the provider name and separated by a comma. To configure the "Shipping" plugin provider in combination with e.g. a decorator called "Example", enter "Shipping,Example" into the input field of the provider. For a list of plugins and decorators that are part of the Aimeos core, please have a look at the [plugin overview](plugins.md).
 
 Label (required)
-: An internal label which helps you to identify the plugin and which can be used for searching in the administration interface.
+: An internal label which helps you to identify the plugin and can be used for searching in the administration interface.
 
 Created (read-only)
 : Date and time when the entry was added. This value is set automatically.

--- a/src/providers/basket-plugins.md
+++ b/src/providers/basket-plugins.md
@@ -1,4 +1,4 @@
-If you want to perform actions on the basket content depending on current activity, basket plug-ins are the tool of choice. They allow you to operate on the whole basket and are able to add, remove or change products, services, coupons or addresses as you wish. Which basket plug-ins are available by default and how to configure them is described in the [user manual](../manual/plugins.md).
+If you want to perform actions on the basket content depending on current activity, basket plugins are the tool of choice. They allow you to operate on the whole basket and are able to add, remove or change products, services, coupons or addresses as you wish. Which basket plugins are available by default and how to configure them is described in the [user manual](../manual/plugins.md).
 
 Your basket plugin must be stored within your project specific [Aimeos extension](../developer/extensions.md) following this path structure:
 ```
@@ -35,77 +35,77 @@ The file containing this code would have to be named `Myexample.php` and be plac
 
 # Event system
 
-The basket plugin system is implemented as event driven process, meaning that your plug-in will get notified if something have happened. Plug-ins have to register for events they want to listen to, so only those plug-ins are executed that actually need to do something. They can listen to these events:
+The basket plugin system is implemented as event driven process, meaning that your plugin will get notified if something has happened. Plugins have to register for events they want to listen to, so only those plugins are executed that actually need to do something. They can listen to these events:
 
 setCustomerId.before, setCustomerId.after
-: Before and after the basket has been associated to the customer, plug-in receives the customer ID
+: Before and after the basket has been associated to the customer, plugin receives the customer ID
 
 setLocale.before, setLocale.after
-: Before and after the locale item with site, language and currency has been added, plug-in receives the locale item
+: Before and after the locale item with site, language and currency has been added, plugin receives the locale item
 
 addProduct.before, addProduct.after
-: Before and after the product item has been added, plug-in receives the order product item
+: Before and after the product item has been added, plugin receives the order product item
 
 deleteProduct.before, deleteProduct.after
-: Before and after the product item has been deleted, plug-in receives the position of the product in the basket before and the deleted order product item afterwards
+: Before and after the product item has been deleted, plugin receives the position of the product in the basket before and the deleted order product item afterwards
 
 setAddress.before, setAddress.after
-: Before and after the address item has been added, plug-in receives the order address item
+: Before and after the address item has been added, plugin receives the order address item
 
 deleteAddress.before, deleteAddress.after
-: Before and after the address item has been deleted, plug-in receives the address type before (usually *\Aimeos\MShop\Order\Item\Base\Address\Base::TYPE_DELIVERY* or *\Aimeos\MShop\Order\Item\Base\Address\Base::TYPE_PAYMENT*) and the deleted order address item afterwards
+: Before and after the address item has been deleted, plugin receives the address type before (usually *\Aimeos\MShop\Order\Item\Base\Address\Base::TYPE_DELIVERY* or *\Aimeos\MShop\Order\Item\Base\Address\Base::TYPE_PAYMENT*) and the deleted order address item afterwards
 
 setService.before, setService.after
-: Before and after the delivery/payment service item has been added, plug-in receives the order service item
+: Before and after the delivery/payment service item has been added, plugin receives the order service item
 
 deleteService.before, deleteService.after
-: Before and after the delivery/payment service item has been deleted, plug-in receives the service type before (usually *\Aimeos\MShop\Order\Item\Base\Service\Base::TYPE_DELIVERY* or *\Aimeos\MShop\Order\Item\Base\Service\Base::TYPE_PAYMENT*) and the deleted order service item afterwards
+: Before and after the delivery/payment service item has been deleted, plugin receives the service type before (usually *\Aimeos\MShop\Order\Item\Base\Service\Base::TYPE_DELIVERY* or *\Aimeos\MShop\Order\Item\Base\Service\Base::TYPE_PAYMENT*) and the deleted order service item afterwards
 
 addCoupon.before, addCoupon.after
-: Before and after the coupon has been added, plug-in receives the list of order product items that are associated to the code before and the coupon code afterwards
+: Before and after the coupon has been added, plugin receives the list of order product items that are associated to the code before and the coupon code afterwards
 
 deleteCoupon.before, deleteCoupon.after
-: Before and after the coupon has been deleted, plug-in receives the coupon code
+: Before and after the coupon has been deleted, plugin receives the coupon code
 
 check.before, check.after
-: Before and after the basket content has been checked, plug-in receives the content types as bitmap (see [`PARTS_*` constants](https://github.com/aimeos/aimeos-core/blob/master/lib/mshoplib/src/MShop/Order/Item/Base/Base.php))
+: Before and after the basket content has been checked, plugin receives the content types as bitmap (see [`PARTS_*` constants](https://github.com/aimeos/aimeos-core/blob/master/lib/mshoplib/src/MShop/Order/Item/Base/Base.php))
 
 setOrder.before
 : Before the order is stored in the database
 
-To listen for such an event, your plug-in has to register itself at the publisher object which is the basket (or *\Aimeos\MShop\Order\Item\Base\Standard* to be more precise). This is done by calling the *addListener()* method of the publisher:
+To listen for such an event, your plugin has to register itself at the publisher object which is the basket (or `\Aimeos\MShop\Order\Item\Base\Standard` to be more precise). This is done by calling the `attach()` method of the publisher:
 
 ```php
 public function register( \Aimeos\MW\Observer\Publisher\Iface $p )
 {
-    $p->addListener( $this, 'addProduct.after' );
-    $p->addListener( $this, 'deleteProduct.after' );
+    $p->attach( $this, 'addProduct.after' );
+    $p->attach( $this, 'deleteProduct.after' );
     // ...
 }
 ```
 
-This would register the plug-in (the $this object) as listener for the *addProduct.after* and *deleteProduct.after* events. A plug-in can register itself to as many events as it needs but you should keep the list of events as short as possible because executing a long list of plug-ins on each action can take some time, especially if the plug-ins generate events itself by changing the content of the basket.
+This would register the plugin (the `$this` object) as listener for the `addProduct.after` and `deleteProduct.after` events. A plugin can register itself to as many events as it needs. Keep the list of events as short as possible, though, since executing a long list of plugins on each action can take some time. This is especially true for plugins that generate their own events that change the content of the basket.
 
 # Main code
 
-The *update()* method of the plug-ins are executed by the basket if an event occurred the plug-in has registered itself to. Thus, you have to put the code that should manipulate the basket into this method. There are some things you should take care of:
+The `update()` method of a plugin is executed by the basket as soon as an event occurred to which the plugin is registered. Thus you have to put the code that should manipulate the basket into this method. There are some things you should take care of:
 
 Check passed order object
 : It must implement *\Aimeos\MShop\Order\Item\Base\Iface*, otherwise you must throw an exception. This protects you against bugs in other extensions.
 
 Protect against multiple invocations
-: In event driven systems, your *update()* method can be called more than once if other plug-ins generate events too by changing the basket. If your code should only be executed once, set a singleton value in your class the first time and skip the code in subsequent calls.
+: In event driven systems, your `update()` method can be called more than once if other plugins generate events that maniulate the basket, too. If your code should only be executed once, set a singleton value in your class the first time it is called, and skip the code in subsequent calls.
 
-Use plug-in configuration values
-: The configuration consists of key/value pairs stored in an array. If a configuration value is required by the plug-in, you should test for it and handle a missing value by either throwing an exception or using a reasonable default value. The configuration options can be set in the [administration interface](../manual/plugin-details.md).
+Use plugin configuration values
+: The configuration consists of key/value pairs stored in an array. If a configuration value is required by the plugin, you should test for it and handle a missing value by either throwing an exception or using a reasonable default value. The configuration options can be set in the [administration interface](../manual/plugin-details.md).
 
 Throw exceptions
-: If something goes wrong, throw an exception of the type *\Aimeos\MShop\Plugin\Provider\Exception*.This class has a special fourth parameter where specific information about the occurred problem can be passed. Please have a look at the [AddressAvailable](https://github.com/aimeos/aimeos-core/blob/master/lib/mshoplib/src/MShop/Plugin/Provider/Order/AddressesAvailable.php) and [ProductGone](https://github.com/aimeos/aimeos-core/blob/master/lib/mshoplib/src/MShop/Plugin/Provider/Order/ProductGone.php) plug-ins for more details.
+: If something goes wrong, throw an exception of type *\Aimeos\MShop\Plugin\Provider\Exception*. This class has a special fourth parameter where specific information about the  problem occurred can be passed. Please have a look at the [AddressAvailable](https://github.com/aimeos/aimeos-core/blob/master/lib/mshoplib/src/MShop/Plugin/Provider/Order/AddressesAvailable.php) and [ProductGone](https://github.com/aimeos/aimeos-core/blob/master/lib/mshoplib/src/MShop/Plugin/Provider/Order/ProductGone.php) plugins for more details.
 
 Return a boolean value
-: The method should return true if everything worked fine. If false is returned, the execution of all following plug-ins for this event is skipped. The advantage is that the code execution is not aborted completely by throwing an exception. You have control over the order of the executed plug-ins by the "position" property in the [administration interface](../manual/plugin-details.md). The plug-in with the lowest number is executed first. If two or more plug-ins share the same number, the order of these plug-ins is arbitrary.
+: The method should return true if everything worked fine. If false is returned, the execution of all following plugins for this event is skipped. The advantage is that the code execution is not aborted completely by throwing an exception. You have control over the order of the executed plugins by the "position" property in the [administration interface](../manual/plugin-details.md). The plugin with the lowest number is executed first. If two or more plugins share the same number, the order of these plugins is arbitrary.
 
-The following implementation shows the important code blocks:
+The following implementation shows the important code blocks of the `update()` method:
 
 ```php
 public function update( \Aimeos\MW\Observer\Publisher\Iface $basket, $event, $value = null )
@@ -131,19 +131,19 @@ public function update( \Aimeos\MW\Observer\Publisher\Iface $basket, $event, $va
 }
 ```
 
-Your plug-in has access to the value handed over by the basket, which depends on the event (the event name is available in the $event parameter). Please have a look into the [list of events](#event-system) to find out what you can expect in $value.
+Your plugin has access to the value handed over by the basket, which depends on the event (the event name is available in the `$event` parameter). Please have a look into the [list of events](#event-system) to find out what you can expect in `$value`.
 
 !!! tip
-    You can log plug-in activities using the "Log" decorator when you need to debug your code, so you will be able to retrace the actions in the log entries. Event-driven code sometimes tends to have surprising effects, especially if other plug-ins create more events by changing the basket content too.
+    You can log plugin activities using the "Log" decorator when you need to debug your code, so you will be able to retrace the actions in the log entries. Event-driven code sometimes tends to have surprising effects, especially if other plugins create more events by changing the basket content, too.
 
 # Decorators
 
-They are a great way to add constraints to the basket plug-ins or to implement functionality that should be available for multiple plug-ins. Decorators are added in the administration interface by adding their name after the plug-in name, separated by a comma.
+Decorators are a great way to add constraints to the basket plugins or to implement functionality that should be available for multiple plugins. They are added in the administration interface by adding their name after the plugin name, separated by a comma.
 
 !!! note
-    It is possible to apply decorators to basket plug-ins globally using the [mshop/plugin/provider/order/decorators](../config/mshop/plugin-provider.md#decorators) configuration setting. Named decorators listed in this configuration array are applied to all plug-ins.
+    It is possible to apply decorators to basket plugins globally using the [mshop/plugin/provider/order/decorators](../config/mshop/plugin-provider.md#decorators) configuration setting. Named decorators listed in this configuration array are applied to all plugins.
 
-All you need to do is to extend from the *\Aimeos\MShop\Plugin\Provider\Decorator\Base* class and overwrite *update()* method where you can apply additional rules to the execution of the original method. Here's an example skeleton for a plug-in decorator:
+All you need to do is to extend from the *\Aimeos\MShop\Plugin\Provider\Decorator\Base* class and overwrite the `update()` method where you can apply additional rules to the execution of the original method. Here's an example skeleton for a plugin decorator:
 
 ```php
 namespace \Aimeos\MShop\Plugin\Provider\Decorator;
@@ -163,9 +163,16 @@ class Example
 }
 ```
 
-The advantage of this approach is, that multiple decorators can be used for one plug-in and that one decorator can be used by multiple plug-ins. This way, the common rules are available for all plug-ins and you can add or remove those rules dynamically without touching the code of your plug-ins.
+The file *Example.php* holding this code would be located at e.g.
 
-These rules can be for example:
+`./<yourext>/lib/custom/src/MShop/Plugin/Provider/Decorators/Example.php`
+
+!!! tip
+    Please also have a look at the *Aimeos Core* which provides a simple [example decorator](https://github.com/aimeos/aimeos-core/blob/master/lib/mshoplib/src/MShop/Plugin/Provider/Order/Example.php)
+
+The advantage of this approach is that multiple decorators can be used for one plugin and that one decorator can be used by multiple plugins. This way the common rules are available for all plugins and you can add or remove those rules dynamically without touching the code of your plugins.
+
+These rules can be:
 
 * execute only for certain locales
 * execute only for registered and logged in customers who already ordered multiple times
@@ -175,29 +182,29 @@ These rules can be for example:
 
 # Testing
 
-Plug-ins and their decorators are objects which can be tested very good but the amount of code required corresponds to the number of managers used inside the classes. As plug-ins mainly operate on a basket instance, unit tests only need to check if the basket content changed in the expected way.
+Plugins and their decorators are objects which can be tested very good but the amount of code required corresponds to the number of managers used inside the classes. As plugins mainly operate on a basket instance, unit tests only need to check if the basket content changed in the expected way.
 
-A test skeleton for a plug-in or decorator is:
+A test skeleton for a plugin or decorator is:
 
 ```php
 namespace \Aimeos\MShop\Plugin\Provider\Order;
 
-class ExampleTest extends \PHPUnit_Framework_TestCase
+class ExampleTest extends \PHPUnit\Framework\TestCase
 {
     private $object;
     private $basket;
-
-    protected function setUp()
+    
+    protected function setUp() : void
     {
-        $context = TestHelperMShop::getContext();
-
-        $pluginManager = \Aimeos\MShopFactory::createManager( $context, 'plugin' );
-        $orderManager = \Aimeos\MShop\Factory::createManager( $context, 'order' );
+        $context = \TestHelper::getContext();
+        
+        $pluginManager = \Aimeos\MShop::create( $context, 'plugin' );
+        $orderManager = \Aimeos\MShop::create( $context, 'order' );
         $orderBaseManager = $orderManager->getSubManager( 'base' );
 
         $this->basket = $orderBaseManager->createItem();
         $plugin = $pluginManager->createItem();
-
+        
         $this->object = new \Aimeos\MShop\Plugin\Provider\Order\Example( $context, $plugin );
     }
 
@@ -208,9 +215,9 @@ class ExampleTest extends \PHPUnit_Framework_TestCase
 
     public function testUpdate()
     {
-        $this->assertTrue( $object->update( $this->basket, 'check.after' ) );
+        $this->assertTrue( $this->object->update( $this->basket, 'check.after' ) );
     }
 }
 ```
 
-You should implement more tests for the *update()* method until every line inside is executed at least once. For more information regarding unit tests please have a look into the [PHPUnit documentation](https://phpunit.readthedocs.io/en/latest/writing-tests-for-phpunit.html). The chapter about [stubs and mocks](https://phpunit.readthedocs.io/en/latest/test-doubles.html) is especially useful if you want to replace the manager objects used in your plug-in during the tests by injecting a mock object into the Aimeos manager factories via the [*inject()*](https://github.com/aimeos/aimeos-core/blob/master/lib/mshoplib/src/MShop.php) method.
+You should implement more tests for the `update()` method until every line inside is executed at least once. For more information regarding unit tests have a look into the [PHPUnit documentation](https://phpunit.readthedocs.io/en/latest/writing-tests-for-phpunit.html). The chapter about [stubs and mocks](https://phpunit.readthedocs.io/en/latest/test-doubles.html) is especially useful if you want to replace the manager objects used in your plugin during the tests by injecting a mock object into the Aimeos manager factories via the [*inject()*](https://github.com/aimeos/aimeos-core/blob/master/lib/mshoplib/src/MShop.php) method.

--- a/src/providers/service/index.md
+++ b/src/providers/service/index.md
@@ -1,8 +1,8 @@
-Delivery and payment handling are one of the most important tasks in a web shop. Most often this involves connecting to external systems and pushing data to them. Therefore, it's vital that a shop system has a feature rich interface that is able to cope with all kinds of special requirements remote services demand.
+Delivery and payment handling are one of the most important tasks in a web shop. Most often this involves connecting to external systems and pushing data to them. Therefore it's vital that a shop system has a feature rich interface that is able to cope with all kinds of special requirements remote services demand.
 
-In Aimeos, the service providers are adapters between the shop interfaces for delivery and payment handling and any remote gateway. They can have arbitrary configurations, individually defined for each service provider. The base classes offer a rich set of methods that ease development and minimize the code that must be written.
+In *Aimeos* the service providers are adapters between the shop interfaces for delivery and payment handling and any remote gateway. They can have arbitrary configurations, individually defined for each service provider. The base classes offer a rich set of methods that ease development and minimize the code that must be written.
 
-Your service provider must be part of your project specific [Aimeos extension](../../developer/extensions.md) you have to create and stored in
+Your service provider must be part of your project specific [*Aimeos* extension](../../developer/extensions.md) and be stored in
 
 ```
 ./<yourext>/lib/custom/src/MShop/Service/Provider/Delivery/<classname>.php
@@ -12,12 +12,12 @@ or
 ./<yourext>/lib/custom/src/MShop/Service/Provider/Payment/<classname>.php
 ```
 
-to be available in your Aimeos installation.
+to be available in your *Aimeos* installation.
 
-For most service providers, you need some configuration values like for username and password to authenticate against external web services. You can store arbitrary numbers of key/value pairs in the service items for each provider which can be checked against a given configuration definition to minimize errors.
+For most service providers you need some configuration values like for username and password to authenticate against external web services. You can store arbitrary numbers of key/value pairs in the service items for each provider which can be checked against a given configuration definition to minimize errors.
 
 !!! warning
-    There are two kinds of configuration definitions: For the fields the customer has to fill out in the front-end and for the shop owner in the administration interface!  Both use the same way and format for their definition, the only difference is by which method they are returned, either by *getConfigFE()* for the front-end or by *getConfigBE()* for the administration interface.
+    There are two kinds of configuration definitions: For the fields the customer has to fill out in the front-end and for the shop owner in the administration interface! Both use the same way and format for their definition, the only difference is by which method they are returned, either by `getConfigFE()` for the front-end or by `getConfigBE()` for the administration interface.
 
 In order to make things as easy as possible, the base service provider class offers some common methods that are often used in provider implementations.
 
@@ -35,7 +35,7 @@ Keep in mind that the order needs to belong to the same site or one of its desce
 
 ## Retrieve complete order
 
-In the order item itself only some status values, dates and related IDs are stored. Most often, you need to get the service data stored in the order because there you can add data related to the payment gateway (e.g. transaction references) and fetch them later if you need them again:
+In the order item itself only some status values, dates and related IDs are stored. Most often you need to get the service data stored in the order because there you can add data related to the payment gateway (e.g. transaction references) and fetch them later if you need them again:
 
 ```php
 $baseItem = $this->getOrderBase( $orderItem->getBaseId() );
@@ -314,7 +314,7 @@ In this method you can also modify the values before storing them. You could enc
 All values can be used later on in the back-end systems but don't have any further effect in the web shop.
 
 !!! note
-    Aimeos don't offer a payment service provider that stores any credit card data. This was an explicit design decision to prevent credit card theft. Please use a payment gateway instead that processes credit card data in a PCI compliant environment.
+    *Aimeos* don't offer a payment service provider that stores any credit card data. This was an explicit design decision to prevent credit card theft. Please use a payment gateway instead that processes credit card data in a PCI compliant environment.
 
 If you need to retrieve data from the fields you defined at your feconfig you can use this code at your Payment Provider:
 


### PR DESCRIPTION
Update example codes to v2020.
Unify the spelling of "plugin" (without dash).

At some places there are links to other documentation pages. Some fixes have been made there, to, in the course of reading and learning, but they are only simple grammar issues and will receive their own proof reading soon. What comes along with this PR should be mergeable without any problems.

Please check the path for the decorator that was added to make the example more complete. In a skype discusson I suggested
`<ext>/lib/custom/src/MShop/Plugin/Provider/Order/Decorators/Example.php`
but after digging more through the aimeos-core I believe it should be without the "Order" in the path:
`<ext>/lib/custom/src/MShop/Plugin/Provider/Decorators/Example.php`

Working through the Example Plugin still does not make my plugin visible in the Plugins list of the Aimeos backend. Why is that? (I first thought this might be the case, because there is no `checkConfigBE` and `getConfigBE` functionality. But so don't plugins like Coupon or FreeProduct. So what makes a plugin actually really appear in the available plugin list?)