### PR TITLE
Adapt first parameter of attach function to the way standard plugins work.

### DIFF
--- a/src/providers/basket-plugins.md
+++ b/src/providers/basket-plugins.md
@@ -84,8 +84,10 @@ To listen for such an event, your plugin has to register itself at the publisher
 ```php
 public function register( \Aimeos\MW\Observer\Publisher\Iface $p )
 {
-    $p->attach( $this, 'addProduct.after' );
-    $p->attach( $this, 'deleteProduct.after' );
+    $plugin = $this->getObject();
+
+    $p->attach( $plugin, 'addProduct.after' );
+    $p->attach( $plugin, 'deleteProduct.after' );
     // ...
 }
 ```


### PR DESCRIPTION
The current version of the attach method is different from what it looks like in the core plugins.

```
# current version
$p->attach( $this, 'addProduct.after' );

# core plugins' version:
$p->attach( $this->getObject(), 'addProduct.after' );

# ...or saved to an intermediary var, when used multiple times:
$plugin = $this->getObject();
	
$p->attach( $plugin, 'addProduct.after' );
$p->attach( $plugin, 'deleteProduct.after' );
```

Please review, thanks!


