### PR TITLE
Grammar fixes.

### DIFF
--- a/src/infrastructure/databases.md
+++ b/src/infrastructure/databases.md
@@ -26,7 +26,7 @@ For MySQL you don't need to change any configuration values in the Aimeos settin
 
 ### Search for short words
 
-By default, the MySQL server stores only words with at least four characters into the fulltext index (and if it's not a stop word). To add shorter words (e.g. with three characters) to the index, you have to adapt the MySQL ft_min_word_len setting in the my.cnf configuration file:
+By default, the MySQL server stores only words with at least four characters into the fulltext index (and only if it's not a stop word). To add shorter words (e.g. with three characters) to the index, you have to adapt the MySQL `ft_min_word_len` setting in the my.cnf configuration file:
 
 ```
 ft_min_word_len = 3
@@ -42,35 +42,35 @@ REPAIR TABLE mshop_index_text QUICK
 
 Depending of the size of the database and the number of rows in the different tables, it might be necessary to adapt some MySQL server settings to get the maximum speed out of Aimeos.
 
-The easiest way to find out if there are any problems caused by e.g. buffers that are too small is the "Status" tab (or "Show MySQL runtime information" link in older versions) on the home screen of phpMyAdmin. It contains the different server variables that can be changed, their value and a description sometimes including hints what to do. The cool thing about this view is that phpMyAdmin highlights the values in red that may be a source of problems.
+The easiest way to find out if there are any problems caused by e.g. buffers that are too small is by looking at the "Status" tab (or "Show MySQL runtime information" link in older versions) on the home screen of phpMyAdmin. It contains the different server variables that can be changed, their values and a description sometimes including hints what to do. The cool thing about this view is that phpMyAdmin highlights the values in red that may be a source of problems.
 
-Especially watch out for these keys:
+Watch out for these keys specifically:
 
 Created_tmp_disk_tables
-: The number of temporary tables that had been written to the hard disk because the buffer was too small. See tmp_table_size if this happened more than a few times
+: The number of temporary tables that have been written to the hard disk because the buffer was too small. See `tmp_table_size` if this happened more than a few times.
 
 Innodb_buffer_pool_reads
-: The number of times index data have to be read from the hard disk because it was not cached in memory. High values may indicate the need to increase the value for innodb_buffer_pool_size
+: The number of times index data have to be read from the hard disk because it was not cached in memory. High values may indicate the need to increase the value for `innodb_buffer_pool_size`.
 
 Qcache_lowmem_prunes
-: The number of queries that had been removed from the query cache because there was no more space left. If this value is high, try to increase query_cache_size
+: The number of queries that had been removed from the query cache because there was no more space left. If this value is high, try to increase `query_cache_size`.
 
 Slow_queries
-: The number of queries that need longer than the configured number of seconds. If this value is high, your server is either to slow for the amount of simultaneous users that are hitting your site or there are some very slow queries executed very often. In the later case check, if you've installed extensions for Aimeos that don't scale well and cause performance problems
+: The number of queries that need longer than the configured number of seconds. If this value is high, your server is either to slow for the amount of simultaneous users that are hitting your site or there are some very slow queries executed very often. In the later case check, if you've installed extensions for Aimeos that don't scale well and cause performance problems.
 
 Sort_merge_passes
-: The number of merge passes the sort algorithm has been forced to do. Higher values can be a hint to increase the sort_buffer_size
+: The number of merge passes the sort algorithm has been forced to do. Higher values can be a hint to increase the `sort_buffer_size`.
 
-These MySQL variables are worth looking for:
+These MySQL variables are worth looking out for:
 
 [innodb_buffer_pool_size](http://dev.mysql.com/doc/refman/8.0/en/innodb-parameters.html#sysvar_innodb_buffer_pool_size)
-: The higher this value, the more data and indexes are available in memory; this is much faster than reading them from the hard disk
+: The higher this value, the more data and indexes are available in memory; this is much faster than reading them from the hard disk.
 
 [sort_buffer_size](http://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_sort_buffer_size)
-: The buffer size that is available for sorting result sets if no index can be used
+: The buffer size that is available for sorting result sets if no index can be used.
 
 [tmp_table_size](http://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_tmp_table_size)
-: The size of the in-memory buffer for temporary tables before they are written to the hard disk
+: The size of the in-memory buffer for temporary tables before they are written to the hard disk.
 
 ### Write performance
 
@@ -89,7 +89,7 @@ innodb_flush_log_at_trx_commit = 2
 
 ### Analyze/optimize tables
 
-MySQL uses the index that fits best to perform the query and the decision is made on the cardinality of the index. Indices with a higher cardinality are preferred over indices with lower ones. Problems arise, when the cardinality is incorrect. Therefore, it's a good idea to check the cardinality values in the "mshop_index_*" tables once in a while, especially if you think the product search is slower than in the past while the number of products is not much higher than before.
+MySQL uses the index that fits best to perform the query. This decision is made on the cardinality of the index. Indices with a higher cardinality are preferred over indices with lower ones. Problems arise, when the cardinality is incorrect. Therefore, it's a good idea to check the cardinality values in the `mshop_index_*` tables once in a while, especially if you think the product search is slower than in the past while the number of products is not much higher than before.
 
 To get rid of the problem you have to execute the MySQL
 
@@ -110,7 +110,7 @@ statement afterwards. The statements are also executed after the index rebuild h
 
 ### Keep indexes in memory
 
-If you have enough RAM, you should try to keep all indexes in memory to reduce the need to access the hard disc to a minimum. Nevertheless, make sure that key_buffer_size + innodb_buffer_pool_size does not exceed 75% of the available RAM and that there's enough RAM for the database connections and the operating system.
+If you have enough RAM, you should try to keep all indexes in memory to reduce the need to access the hard disc to a minimum. Nevertheless, make sure that the total amount of `key_buffer_size + innodb_buffer_pool_size` does not exceed 75% of the available RAM and that there is enough RAM for the database connections and the operating system.
 
 To find out the size (in MB) of all indexes, use these statements:
 
@@ -123,7 +123,7 @@ FROM information_schema.tables WHERE engine = 'InnoDB';
 
 To get the maximum performance that is possible it's necessary to reduce the need to access the hard disc to a minimum. For this, you must have enough RAM to store the indexes of the "mshop_index_*" tables into the MySQL cache.
 
-For InnoDB tables, the OPTIMIZE TABLE statement makes sure that the complete indexes (and data as InnoDB stores both in one data structure) of the tables are in the cache if it's big enough:
+For InnoDB tables, the `OPTIMIZE TABLE` statement makes sure that all the indexes (and data, since InnoDB stores both in one data structure) of the tables are in the cache if it's big enough:
 
 ```sql
 OPTIMIZE TABLE mshop_index_attribute
@@ -140,7 +140,7 @@ OPTIMIZE TABLE mshop_product_list
 
 ## PostgreSQL
 
-For PostgreSQL servers, you need to reset some configuration and configure PostgreSQL specific classes for maximum performance:
+For PostgreSQL servers, you need to reset some configuration options and configure PostgreSQL specific classes for maximum performance:
 
 ```php
 'resource' => [
@@ -188,7 +188,7 @@ For PostgreSQL servers, you need to reset some configuration and configure Postg
 
 # Multiple databases
 
-The Aimeos e-commerce components are able to use different databases for its data domains. Thus, you can configure a separate database e.g. for all customer or order related data. These database can even use different database servers like MySQL, PostgreSQL, Oracle, SQL Server, etc. If no specific database is configured for a data domain, the default database will be used.
+The Aimeos e-commerce components are able to use different databases for their data domains. Thus, you can, e.g., configure a separate database for all customer or order related data. These databases can even use different database servers like MySQL, PostgreSQL, Oracle, SQL Server, etc. If no specific database is configured for a data domain, the default database will be used.
 
 In fact, there are 16 different data domains which can be stored in one database each. These include domains for:
 
@@ -211,7 +211,7 @@ In fact, there are 16 different data domains which can be stored in one database
 * text
 
 !!! tip
-    Usually it doesn't make sense to put every data domain into an own database. Reasonable data domains are those which will grow very big in your setup. Candidates are the **log** and **order** domains which might fill up with data over the time.
+    Usually it doesn't make sense to assign every data domain to its own database. Reasonable data domains are those which will grow very big in your setup. Candidates are the **log** and **order** domains which might fill up with data over the time.
 
 You need to create a **resource.php** file in the config directory that will contain the database configuration:
 
@@ -232,7 +232,7 @@ return [
 ];
 ```
 
-You can add an entry for every data domain replacing the *<domain>* placeholder in the example above with the name of the data domain. For the customer data domain it would be e.g.
+You can add an entry for every data domain replacing the *<domain>* placeholder in the example above with the name of the data domain. E.g., for the customer data domain it would be:
 
 ```php
     'db-customer' => [
@@ -248,7 +248,7 @@ You can add an entry for every data domain replacing the *<domain>* placeholder 
     ],
 ```
 
-The fallback database (which is also the standard database) is already configured within the Aimeos TYPO3 extension and is the one of your TYPO3 installation. If you want to move the shop related tables to their own database, add a configuration entry for **db** to your configuration file:
+The fallback database (which is also the standard database) is already configured in your installation. If you want to move the shop related tables to their own database, add a configuration entry for **db** to your configuration file:
 
 ```php
     'db' => [
@@ -257,4 +257,4 @@ The fallback database (which is also the standard database) is already configure
 ```
 
 !!! warning
-    During a request, only one database connection per configured database should be open. Limiting the maximum connections to "1" works until you try to execute run the setup tasks as some of them need two connections to for reading and writing in parallel.
+    During a request, only one database connection per configured database should be open. Limiting the maximum connections to "1" works until you try to execute the setup tasks, because some of the configured databases need two connections to for reading and writing in parallel.


### PR DESCRIPTION
Due to a mess-up I lost a previous fork of this repo, from which this PR stemmed:
https://github.com/aimeos/aimeos-docs/pull/11

This new PR supersedes the old one including the recommendations.

Please check line 113:
The old PR had a comment that did not agree with the formulation
`[...] make sure that `key_buffer_size` and `innodb_buffer_pool_size` do not exceed [...]`
The comment said: 
`key_buffer_size + innodb_buffer_pool_size is intended because the sum should not exceed 75% RAM`
The new formulation undid this change.
