### PR TITLE
Typo3: Add route param default value to prevent invalid URI generation

### DIFF
--- a/src/typo3/setup.md
+++ b/src/typo3/setup.md
@@ -170,6 +170,7 @@ routeEnhancers:
     defaults:
       b_action: ''
       c_step: ''
+      f_name: 'c'
       f_sort: ''
       d_pos: ''
 ```


### PR DESCRIPTION
See https://github.com/aimeos/ai-client-html/pull/157